### PR TITLE
Removed need to use null as request body

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "com.pusher.chatkit"
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -20,11 +20,10 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.android.support:design:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/app/src/main/java/com/pusher/chatkit/sample/ChatRoomActivity.java
+++ b/app/src/main/java/com/pusher/chatkit/sample/ChatRoomActivity.java
@@ -303,7 +303,7 @@ public class ChatRoomActivity extends AppCompatActivity {
                         public void onCurrentUser(@NonNull CurrentUser user) {
 
                             Room room = user.getRoom(roomId);
-                            user.sendMessage(room.getId(), messageText.getText().toString(), NoAttachment.INSTANCE, new MessageSentListener() {
+                            user.sendMessage(room.getId(), messageText.getText().toString(), new MessageSentListener() {
                                 @Override
                                 public void onMessage(int messageId) {
                                     Timber.d("Message sent without attachment! %d", messageId);

--- a/app/src/main/java/com/pusher/chatkit/sample/ChatRoomActivity.java
+++ b/app/src/main/java/com/pusher/chatkit/sample/ChatRoomActivity.java
@@ -24,6 +24,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.database.Cursor;
 
+import com.pusher.chatkit.AttachmentBody;
 import com.pusher.chatkit.CurrentUser;
 import com.pusher.chatkit.CurrentUserListener;
 import com.pusher.chatkit.CursorsSubscriptionListenersAdapter;
@@ -35,6 +36,7 @@ import com.pusher.chatkit.GenericAttachment;
 import com.pusher.chatkit.LinkAttachment;
 import com.pusher.chatkit.Message;
 import com.pusher.chatkit.MessageSentListener;
+import com.pusher.chatkit.NoAttachment;
 import com.pusher.chatkit.Room;
 import com.pusher.chatkit.RoomSubscriptionListenersAdapter;
 import com.pusher.chatkit.SetCursorListener;
@@ -301,7 +303,7 @@ public class ChatRoomActivity extends AppCompatActivity {
                         public void onCurrentUser(@NonNull CurrentUser user) {
 
                             Room room = user.getRoom(roomId);
-                            user.sendMessage(room.getId(), messageText.getText().toString(), null, new MessageSentListener() {
+                            user.sendMessage(room.getId(), messageText.getText().toString(), NoAttachment.INSTANCE, new MessageSentListener() {
                                 @Override
                                 public void onMessage(int messageId) {
                                     Timber.d("Message sent without attachment! %d", messageId);

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext {
+        kotlin_version = '1.2.21'
+    }
     repositories {
         google()
         jcenter()

--- a/chatkit/build.gradle
+++ b/chatkit/build.gradle
@@ -3,13 +3,12 @@ apply plugin: 'kotlin-android'
 apply from: 'maven-push.gradle'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
-
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -32,10 +31,10 @@ kotlin {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.21.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.1'
 
     api 'com.pusher:pusher-platform-android:0.3.0'
     // Use if you're developing locally in conjunction with pusher-platform-android

--- a/chatkit/src/main/java/com/pusher/chatkit/AttachmentTypes.kt
+++ b/chatkit/src/main/java/com/pusher/chatkit/AttachmentTypes.kt
@@ -7,3 +7,5 @@ sealed class GenericAttachment
 data class DataAttachment(val file: File, val name: String): GenericAttachment()
 
 data class LinkAttachment(val link: String, val type: String): GenericAttachment()
+
+object NoAttachment : GenericAttachment()

--- a/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
@@ -3,41 +3,41 @@ package com.pusher.chatkit
 import android.os.Handler
 import android.os.Looper
 import com.google.gson.annotations.SerializedName
-import com.google.gson.reflect.TypeToken
 import com.pusher.chatkit.ChatManager.Companion.GSON
 import com.pusher.platform.Instance
-import com.pusher.platform.RequestDestination
 import com.pusher.platform.RequestOptions
 import com.pusher.platform.logger.Logger
 import com.pusher.platform.tokenProvider.TokenProvider
+import okhttp3.HttpUrl
+import java.util.concurrent.ConcurrentHashMap
+import com.google.gson.reflect.TypeToken
+import com.pusher.platform.RequestDestination
 import elements.Error
 import kotlinx.coroutines.experimental.async
-import okhttp3.HttpUrl
 import java.io.File
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.experimental.suspendCoroutine
 
 
 class CurrentUser(
-    rooms: List<Room>,
-    val apiInstance: Instance,
-    val createdAt: String,
-    val cursors: ConcurrentHashMap<Int, Cursor>,
-    val cursorsInstance: Instance,
-    val id: String,
-    val logger: Logger,
-    val filesInstance: Instance,
-    val tokenParams: ChatkitTokenParams?,
-    val tokenProvider: TokenProvider,
-    val userStore: GlobalUserStore,
-    var avatarURL: String?,
-    var customData: CustomData?,
-    var name: String?,
-    var updatedAt: String
+        rooms: List<Room>,
+        val apiInstance: Instance,
+        val createdAt: String,
+        val cursors: ConcurrentHashMap<Int, Cursor>,
+        val cursorsInstance: Instance,
+        val id: String,
+        val logger: Logger,
+        val filesInstance: Instance,
+        val tokenParams: ChatkitTokenParams?,
+        val tokenProvider: TokenProvider,
+        val userStore: GlobalUserStore,
+        var avatarURL: String?,
+        var customData: CustomData?,
+        var name: String?,
+        var updatedAt: String
 ) {
     val mainThread = Handler(Looper.getMainLooper())
 
-    fun updateWithPropertiesOf(newUser: User) {
+    fun updateWithPropertiesOf(newUser: User){
         updatedAt = newUser.updatedAt
         name = newUser.name
         customData = newUser.customData
@@ -58,112 +58,109 @@ class CurrentUser(
     fun getRoom(id: Int): Room? = roomStore.rooms[id]
 
     //Room membership related information
-    @JvmOverloads
-    fun createRoom(
-        name: String,
-        isPrivate: Boolean = false,
-        userIds: Array<String>? = null,
-        onRoomCreatedListener: RoomListener,
-        onErrorListener: ErrorListener
-    ) {
+    @JvmOverloads fun createRoom(
+            name: String,
+            isPrivate: Boolean = false,
+            userIds: Array<String>? = null,
+            onRoomCreatedListener: RoomListener,
+            onErrorListener: ErrorListener
+    ){
         val roomRequest = RoomCreateRequest(
-            name = name,
-            private = isPrivate,
-            createdById = id,
-            userIds = userIds
+                name = name,
+                private = isPrivate,
+                createdById = id,
+                userIds = userIds
         )
 
         apiInstance.request(
-            options = RequestOptions(
-                method = "POST",
-                path = "/rooms",
-                body = GSON.toJson(roomRequest)
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { response ->
-                val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
+                options = RequestOptions(
+                        method = "POST",
+                        path = "/rooms",
+                        body = GSON.toJson(roomRequest)
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { response ->
+                    val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
 
-                roomStore.addOrMerge(room)
-                populateRoomUserStore(room)
+                    roomStore.addOrMerge(room)
+                    populateRoomUserStore(room)
 
-                mainThread.post { onRoomCreatedListener.onRoom(room) }
+                    mainThread.post { onRoomCreatedListener.onRoom(room) }
 
-            },
-            onFailure = { error ->
-                mainThread.post { onErrorListener.onError(error) }
-            }
+                },
+                onFailure = { error ->
+                    mainThread.post { onErrorListener.onError(error) }
+                }
         )
     }
 
-    @JvmOverloads
-    fun getUserRooms(onlyJoinable: Boolean = false, onCompleteListener: RoomsListener) {
+    @JvmOverloads fun getUserRooms(onlyJoinable: Boolean = false, onCompleteListener: RoomsListener){
 
         val roomListType = object : TypeToken<List<Room>>() {}.getType()
         val path = "/users/$id/rooms"
         apiInstance.request(
-            options = RequestOptions(
-                method = "GET",
-                path = path + "?joinable=$onlyJoinable"
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { response ->
-                val rooms = GSON.fromJson<List<Room>>(response.body()!!.string(), roomListType)
-                onCompleteListener.onRooms(rooms)
-            },
-            onFailure = {
-                logger.error("Tragedy! No rooms could have been returned!")
-            }
+                options = RequestOptions(
+                    method = "GET",
+                    path = path+"?joinable=$onlyJoinable"
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { response ->
+                    val rooms = GSON.fromJson<List<Room>>(response.body()!!.string(), roomListType)
+                    onCompleteListener.onRooms(rooms)
+                },
+                onFailure = {
+                    logger.error("Tragedy! No rooms could have been returned!")
+                }
         )
     }
 
-    fun getJoinableRooms(onCompleteListener: RoomsListener) {
+    fun getJoinableRooms(onCompleteListener: RoomsListener){
         getUserRooms(onlyJoinable = true, onCompleteListener = onCompleteListener)
     }
 
-    @JvmOverloads
-    fun subscribeToRoom(
-        room: Room,
-        messageLimit: Int = 20,
-        listeners: RoomSubscriptionListeners,
-        cursorsListeners: CursorsSubscriptionListeners? = null
-    ) {
+    @JvmOverloads fun subscribeToRoom(
+            room: Room,
+            messageLimit: Int = 20,
+            listeners: RoomSubscriptionListeners,
+            cursorsListeners: CursorsSubscriptionListeners? = null
+    ){
         val roomSubscription = RoomSubscription(this, room, userStore, listeners)
         apiInstance.subscribeResuming(
-            path = "/rooms/${room.id}?user_id=$id&message_limit=$messageLimit",
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            listeners = roomSubscription.subscriptionListeners
+                path = "/rooms/${room.id}?user_id=$id&message_limit=$messageLimit",
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                listeners = roomSubscription.subscriptionListeners
         )
         if (cursorsListeners == null) {
             return
         }
         val cursorsSubscription = CursorsSubscription(this, room, userStore, cursorsListeners)
         cursorsInstance.subscribeResuming(
-            path = "/cursors/0/rooms/${room.id}/",
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            listeners = cursorsSubscription.subscriptionListeners
+                path = "/cursors/0/rooms/${room.id}/",
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                listeners = cursorsSubscription.subscriptionListeners
         )
     }
 
     fun setCursor(
-        position: Int,
-        room: Room,
-        onCompleteListener: SetCursorListener,
-        onErrorListener: ErrorListener
+            position: Int,
+            room: Room,
+            onCompleteListener: SetCursorListener,
+            onErrorListener: ErrorListener
     ) {
         cursorsInstance.request(
-            options = RequestOptions(
-                method = "PUT",
-                path = "/cursors/0/rooms/${room.id}/users/$id",
-                body = GSON.toJson(SetCursorRequest(position))
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { onCompleteListener.onSetCursor() },
-            onFailure = { onErrorListener.onError(it) }
+                options = RequestOptions(
+                        method = "PUT",
+                        path = "/cursors/0/rooms/${room.id}/users/$id",
+                        body = GSON.toJson(SetCursorRequest(position))
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { onCompleteListener.onSetCursor() },
+                onFailure = { onErrorListener.onError(it) }
         )
     }
 
@@ -172,26 +169,26 @@ class CurrentUser(
         room.memberUserIds.forEach { userId ->
 
             userStore.findOrGetUser(
-                id = userId,
-                userListener = UserListener { user -> room.userStore().addOrMerge(user) },
-                errorListener = ErrorListener {
-                    TODO("Not implemented")
+                    id = userId,
+                    userListener = UserListener { user -> room.userStore().addOrMerge(user) },
+                    errorListener = ErrorListener {
+                        TODO("Not implemented")
 
-                }
+                    }
             )
         }
     }
 
     fun sendMessage(
-        roomId: Int,
-        text: String,
-        onCompleteListener: MessageSentListener,
-        onErrorListener: ErrorListener
+            roomId: Int,
+            text: String,
+            onCompleteListener: MessageSentListener,
+            onErrorListener: ErrorListener
     ) {
         async {
             val sendMesageRes = sendCompleteMessage(
-                roomId = roomId,
-                text = text
+                    roomId = roomId,
+                    text = text
             )
 
             when (sendMesageRes) {
@@ -206,11 +203,11 @@ class CurrentUser(
     }
 
     fun sendMessage(
-        roomId: Int,
-        text: String? = null,
-        attachment: GenericAttachment,
-        onCompleteListener: MessageSentListener,
-        onErrorListener: ErrorListener
+            roomId: Int,
+            text: String? = null,
+            attachment: GenericAttachment,
+            onCompleteListener: MessageSentListener,
+            onErrorListener: ErrorListener
     ) {
         async {
             val attachmentBody = when (attachment) {
@@ -249,64 +246,64 @@ class CurrentUser(
     }
 
     private suspend fun sendCompleteMessage(
-        roomId: Int,
-        text: String? = null,
-        attachment: AttachmentBody? = null
+            roomId: Int,
+            text: String? = null,
+            attachment: AttachmentBody? = null
     ): Result<MessageSendingResponse, Error> = suspendCoroutine {
         val path = "/rooms/$roomId/messages"
-        val message = MessageRequest(text, id, attachment)
+        val message = MessageRequest(text = text, userId = id, attachment = attachment)
         apiInstance.request(
-            options = RequestOptions(
-                method = "POST",
-                path = path,
-                body = GSON.toJson(message)
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { res ->
-                val messageRes = GSON.fromJson<MessageSendingResponse>(res.body()!!.charStream(), MessageSendingResponse::class.java)
-                it.resume(Ok(messageRes))
-            },
-            onFailure = { err -> it.resume(Err(err)) }
+                options = RequestOptions(
+                        method = "POST",
+                        path = path,
+                        body = GSON.toJson(message)
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { res ->
+                    val messageRes = GSON.fromJson<MessageSendingResponse>(res.body()!!.charStream(), MessageSendingResponse::class.java)
+                    it.resume(Ok(messageRes))
+                },
+                onFailure = { err -> it.resume(Err(err)) }
         )
     }
 
     fun fetchAttachment(
-        attachmentUrl: String,
-        onCompleteListener: FetchedAttachmentListener,
-        onErrorListener: ErrorListener
+            attachmentUrl: String,
+            onCompleteListener: FetchedAttachmentListener,
+            onErrorListener: ErrorListener
     ) {
         filesInstance.request(
-            options = RequestOptions(
-                method = "GET",
-                destination = RequestDestination.Absolute(attachmentUrl)
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { response ->
-                val fetchedAttachment = GSON.fromJson<FetchedAttachment>(response.body()!!.charStream(), FetchedAttachment::class.java)
-                onCompleteListener.onFetch(fetchedAttachment)
-            },
-            onFailure = { error -> onErrorListener.onError(error) }
+                options = RequestOptions(
+                        method = "GET",
+                        destination = RequestDestination.Absolute(attachmentUrl)
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { response ->
+                    val fetchedAttachment = GSON.fromJson<FetchedAttachment>(response.body()!!.charStream(), FetchedAttachment::class.java)
+                    onCompleteListener.onFetch(fetchedAttachment)
+                },
+                onFailure = { error -> onErrorListener.onError(error) }
 
         )
     }
 
     private suspend fun uploadFile(
-        file: File,
-        fileName: String,
-        roomId: Int
+            file: File,
+            fileName: String,
+            roomId: Int
     ): Result<AttachmentBody, Error> = suspendCoroutine {
         filesInstance.upload(
-            path = "/rooms/$roomId/files/$fileName",
-            file = file,
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { res ->
-                val attachmentBody = GSON.fromJson<AttachmentBody>(res.body()!!.charStream(), AttachmentBody::class.java)
-                it.resume(Ok(attachmentBody))
-            },
-            onFailure = { err -> it.resume(Err(err)) }
+                path = "/rooms/$roomId/files/$fileName",
+                file = file,
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { res ->
+                    val attachmentBody = GSON.fromJson<AttachmentBody>(res.body()!!.charStream(), AttachmentBody::class.java)
+                    it.resume(Ok(attachmentBody))
+                },
+                onFailure = { err -> it.resume(Err(err)) }
         )
     }
 
@@ -317,11 +314,11 @@ class CurrentUser(
     fun removeUsers(roomId: Int, userIds: Array<String>, completeListener: OnCompleteListener, errorListener: ErrorListener) = addOrRemoveUsers("remove", roomId, userIds, completeListener, errorListener)
 
     private fun addOrRemoveUsers(
-        operation: String,
-        roomId: Int,
-        userIds: Array<String>,
-        completeListener: OnCompleteListener,
-        errorListener: ErrorListener) {
+            operation: String,
+            roomId: Int,
+            userIds: Array<String>,
+            completeListener: OnCompleteListener,
+            errorListener: ErrorListener){
 
         val data = object {
             val userIds = userIds
@@ -329,15 +326,15 @@ class CurrentUser(
 
         val path = "/rooms/$roomId/users/$operation"
         apiInstance.request(
-            options = RequestOptions(
-                method = "PUT",
-                path = path,
-                body = GSON.toJson(data)
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { completeListener.onComplete() },
-            onFailure = { error -> errorListener.onError(error) }
+                options = RequestOptions(
+                        method = "PUT",
+                        path = path,
+                        body = GSON.toJson(data)
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { completeListener.onComplete() },
+                onFailure = { error -> errorListener.onError(error) }
         )
     }
 
@@ -346,28 +343,28 @@ class CurrentUser(
      * */
 
     fun updateRoom(
-        room: Room,
-        name: String? = null,
-        isPrivate: Boolean? = null,
-        completeListener: OnCompleteListener,
-        errorListener: ErrorListener
-    ) {
+            room: Room,
+            name: String? = null,
+            isPrivate: Boolean? = null,
+            completeListener: OnCompleteListener,
+            errorListener: ErrorListener
+    ){
         val path = "/rooms/${room.id}"
         val data = UpdateRoomRequest(
-            name = name ?: room.name,
-            isPrivate = isPrivate ?: room.isPrivate
+                    name = name ?: room.name,
+                    isPrivate =  isPrivate ?: room.isPrivate
         )
 
         apiInstance.request(
-            options = RequestOptions(
-                method = "PUT",
-                path = path,
-                body = GSON.toJson(data)
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { mainThread.post { completeListener.onComplete() } },
-            onFailure = { error -> mainThread.post { errorListener.onError(error) } }
+                options = RequestOptions(
+                        method = "PUT",
+                        path = path,
+                        body = GSON.toJson(data)
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { mainThread.post {  completeListener.onComplete() } },
+                onFailure = { error -> mainThread.post { errorListener.onError(error) } }
         )
     }
 
@@ -380,21 +377,21 @@ class CurrentUser(
     fun deleteRoom(room: Room, completeListener: OnCompleteListener, errorListener: ErrorListener) = deleteRoom(room.id, completeListener, errorListener)
 
     fun deleteRoom(
-        roomId: Int,
-        completeListener: OnCompleteListener,
-        errorListener: ErrorListener
-    ) {
+            roomId: Int,
+            completeListener: OnCompleteListener,
+            errorListener: ErrorListener
+    ){
         val path = "/rooms/$roomId"
         apiInstance.request(
-            options = RequestOptions(
-                method = "DELETE",
-                path = path,
-                body = ""
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { mainThread.post { completeListener.onComplete() } },
-            onFailure = { error -> mainThread.post { errorListener.onError(error) } }
+                options = RequestOptions(
+                        method = "DELETE",
+                        path = path,
+                        body = ""
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { mainThread.post {  completeListener.onComplete() } },
+                onFailure = { error -> mainThread.post { errorListener.onError(error) } }
         )
     }
 
@@ -404,32 +401,32 @@ class CurrentUser(
     fun joinRoom(room: Room, completeListener: RoomListener, errorListener: ErrorListener) = joinRoom(room.id, completeListener, errorListener)
 
     fun joinRoom(
-        roomId: Int,
-        completeListener: RoomListener,
-        errorListener: ErrorListener
-    ) {
-        val wrappedCompleteListener = RoomListener { room -> mainThread.post { completeListener.onRoom(room) } }
-        val wrappedErrorListener = ErrorListener { error -> mainThread.post { errorListener.onError(error) } }
+            roomId: Int,
+            completeListener: RoomListener,
+            errorListener: ErrorListener
+    ){
+        val wrappedCompleteListener = RoomListener { room -> mainThread.post { completeListener.onRoom(room) }}
+        val wrappedErrorListener = ErrorListener { error -> mainThread.post { errorListener.onError(error) }}
 
         val path = HttpUrl.parse("https://pusherplatform.io")!!.newBuilder().addPathSegments("/users/$id/rooms/$roomId/join").build().encodedPath()
 
         apiInstance.request(
-            options = RequestOptions(
-                method = "POST",
-                path = path,
-                body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { response ->
+                options = RequestOptions(
+                        method = "POST",
+                        path = path,
+                        body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { response ->
 
-                val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
-                roomStore.addOrMerge(room)
-                populateRoomUserStore(room)
-                wrappedCompleteListener.onRoom(room)
+                    val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
+                    roomStore.addOrMerge(room)
+                    populateRoomUserStore(room)
+                    wrappedCompleteListener.onRoom(room)
 
-            },
-            onFailure = { error -> wrappedErrorListener.onError(error) }
+                },
+                onFailure = { error -> wrappedErrorListener.onError(error) }
         )
     }
 
@@ -440,35 +437,35 @@ class CurrentUser(
     fun leaveRoom(room: Room, completeListener: OnCompleteListener, errorListener: ErrorListener) = leaveRoom(room.id, completeListener, errorListener)
 
     fun leaveRoom(
-        roomId: Int,
-        completeListener: OnCompleteListener,
-        errorListener: ErrorListener
-    ) {
+            roomId: Int,
+            completeListener: OnCompleteListener,
+            errorListener: ErrorListener
+    ){
         val path = HttpUrl.parse("https://pusherplatform.io")!!.newBuilder().addPathSegments("/users/$id/rooms/$roomId/leave").build().encodedPath()
 
         apiInstance.request(
-            options = RequestOptions(
-                method = "POST",
-                path = path,
-                body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
-            ),
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            onSuccess = { completeListener.onComplete() },
-            onFailure = { error -> errorListener.onError(error) }
+                options = RequestOptions(
+                        method = "POST",
+                        path = path,
+                        body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
+                ),
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                onSuccess = { completeListener.onComplete() },
+                onFailure = { error -> errorListener.onError(error) }
         )
     }
 
     fun establishPresenceSubscription(listeners: ThreadedUserSubscriptionListeners) {
 
         presenceSubscription = PresenceSubscription(
-            instance = apiInstance,
-            path = "/users/$id/presence",
-            listeners = listeners,
-            tokenProvider = tokenProvider,
-            tokenParams = tokenParams,
-            userStore = userStore,
-            logger = logger
+                instance = apiInstance,
+                path = "/users/$id/presence",
+                listeners = listeners,
+                tokenProvider = tokenProvider,
+                tokenParams = tokenParams,
+                userStore = userStore,
+                logger = logger
         )
     }
 }
@@ -485,16 +482,16 @@ data class SetCursorRequest(val position: Int)
 data class MessageSendingResponse(val messageId: Int)
 
 data class RoomCreateRequest(
-    val name: String,
-    val private: Boolean,
-    val createdById: String,
-    var userIds: Array<String>? = null
+        val name: String,
+        val private: Boolean,
+        val createdById: String,
+        var userIds: Array<String>? = null
 )
 
 data class FetchedAttachment(
-    val file: FetchedAttachmentFile,
-    @SerializedName("resource_link") val link: String,
-    val ttl: Double
+        val file: FetchedAttachmentFile,
+        @SerializedName("resource_link") val link: String,
+        val ttl: Double
 )
 
 data class FetchedAttachmentFile(val bytes: Int, val lastModified: Double, val name: String)

--- a/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
@@ -205,7 +205,7 @@ class CurrentUser(
     fun sendMessage(
             roomId: Int,
             text: String? = null,
-            attachment: GenericAttachment,
+            attachment: GenericAttachment?,
             onCompleteListener: MessageSentListener,
             onErrorListener: ErrorListener
     ) {

--- a/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
@@ -179,33 +179,11 @@ class CurrentUser(
         }
     }
 
-    fun sendMessage(
-            roomId: Int,
-            text: String,
-            onCompleteListener: MessageSentListener,
-            onErrorListener: ErrorListener
-    ) {
-        async {
-            val sendMesageRes = sendCompleteMessage(
-                    roomId = roomId,
-                    text = text
-            )
-
-            when (sendMesageRes) {
-                is Ok -> {
-                    onCompleteListener.onMessage(sendMesageRes.value.messageId)
-                }
-                is Err -> {
-                    onErrorListener.onError(sendMesageRes.error)
-                }
-            }
-        }
-    }
-
+    @JvmOverloads
     fun sendMessage(
             roomId: Int,
             text: String? = null,
-            attachment: GenericAttachment,
+            attachment: GenericAttachment = NoAttachment,
             onCompleteListener: MessageSentListener,
             onErrorListener: ErrorListener
     ) {

--- a/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit/src/main/java/com/pusher/chatkit/CurrentUser.kt
@@ -3,41 +3,41 @@ package com.pusher.chatkit
 import android.os.Handler
 import android.os.Looper
 import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import com.pusher.chatkit.ChatManager.Companion.GSON
 import com.pusher.platform.Instance
+import com.pusher.platform.RequestDestination
 import com.pusher.platform.RequestOptions
 import com.pusher.platform.logger.Logger
 import com.pusher.platform.tokenProvider.TokenProvider
-import okhttp3.HttpUrl
-import java.util.concurrent.ConcurrentHashMap
-import com.google.gson.reflect.TypeToken
-import com.pusher.platform.RequestDestination
 import elements.Error
 import kotlinx.coroutines.experimental.async
+import okhttp3.HttpUrl
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.experimental.suspendCoroutine
 
 
 class CurrentUser(
-        rooms: List<Room>,
-        val apiInstance: Instance,
-        val createdAt: String,
-        val cursors: ConcurrentHashMap<Int, Cursor>,
-        val cursorsInstance: Instance,
-        val id: String,
-        val logger: Logger,
-        val filesInstance: Instance,
-        val tokenParams: ChatkitTokenParams?,
-        val tokenProvider: TokenProvider,
-        val userStore: GlobalUserStore,
-        var avatarURL: String?,
-        var customData: CustomData?,
-        var name: String?,
-        var updatedAt: String
+    rooms: List<Room>,
+    val apiInstance: Instance,
+    val createdAt: String,
+    val cursors: ConcurrentHashMap<Int, Cursor>,
+    val cursorsInstance: Instance,
+    val id: String,
+    val logger: Logger,
+    val filesInstance: Instance,
+    val tokenParams: ChatkitTokenParams?,
+    val tokenProvider: TokenProvider,
+    val userStore: GlobalUserStore,
+    var avatarURL: String?,
+    var customData: CustomData?,
+    var name: String?,
+    var updatedAt: String
 ) {
     val mainThread = Handler(Looper.getMainLooper())
 
-    fun updateWithPropertiesOf(newUser: User){
+    fun updateWithPropertiesOf(newUser: User) {
         updatedAt = newUser.updatedAt
         name = newUser.name
         customData = newUser.customData
@@ -58,109 +58,112 @@ class CurrentUser(
     fun getRoom(id: Int): Room? = roomStore.rooms[id]
 
     //Room membership related information
-    @JvmOverloads fun createRoom(
-            name: String,
-            isPrivate: Boolean = false,
-            userIds: Array<String>? = null,
-            onRoomCreatedListener: RoomListener,
-            onErrorListener: ErrorListener
-    ){
+    @JvmOverloads
+    fun createRoom(
+        name: String,
+        isPrivate: Boolean = false,
+        userIds: Array<String>? = null,
+        onRoomCreatedListener: RoomListener,
+        onErrorListener: ErrorListener
+    ) {
         val roomRequest = RoomCreateRequest(
-                name = name,
-                private = isPrivate,
-                createdById = id,
-                userIds = userIds
+            name = name,
+            private = isPrivate,
+            createdById = id,
+            userIds = userIds
         )
 
         apiInstance.request(
-                options = RequestOptions(
-                        method = "POST",
-                        path = "/rooms",
-                        body = GSON.toJson(roomRequest)
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { response ->
-                    val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
+            options = RequestOptions(
+                method = "POST",
+                path = "/rooms",
+                body = GSON.toJson(roomRequest)
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { response ->
+                val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
 
-                    roomStore.addOrMerge(room)
-                    populateRoomUserStore(room)
+                roomStore.addOrMerge(room)
+                populateRoomUserStore(room)
 
-                    mainThread.post { onRoomCreatedListener.onRoom(room) }
+                mainThread.post { onRoomCreatedListener.onRoom(room) }
 
-                },
-                onFailure = { error ->
-                    mainThread.post { onErrorListener.onError(error) }
-                }
+            },
+            onFailure = { error ->
+                mainThread.post { onErrorListener.onError(error) }
+            }
         )
     }
 
-    @JvmOverloads fun getUserRooms(onlyJoinable: Boolean = false, onCompleteListener: RoomsListener){
+    @JvmOverloads
+    fun getUserRooms(onlyJoinable: Boolean = false, onCompleteListener: RoomsListener) {
 
         val roomListType = object : TypeToken<List<Room>>() {}.getType()
         val path = "/users/$id/rooms"
         apiInstance.request(
-                options = RequestOptions(
-                    method = "GET",
-                    path = path+"?joinable=$onlyJoinable"
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { response ->
-                    val rooms = GSON.fromJson<List<Room>>(response.body()!!.string(), roomListType)
-                    onCompleteListener.onRooms(rooms)
-                },
-                onFailure = {
-                    logger.error("Tragedy! No rooms could have been returned!")
-                }
+            options = RequestOptions(
+                method = "GET",
+                path = path + "?joinable=$onlyJoinable"
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { response ->
+                val rooms = GSON.fromJson<List<Room>>(response.body()!!.string(), roomListType)
+                onCompleteListener.onRooms(rooms)
+            },
+            onFailure = {
+                logger.error("Tragedy! No rooms could have been returned!")
+            }
         )
     }
 
-    fun getJoinableRooms(onCompleteListener: RoomsListener){
+    fun getJoinableRooms(onCompleteListener: RoomsListener) {
         getUserRooms(onlyJoinable = true, onCompleteListener = onCompleteListener)
     }
 
-    @JvmOverloads fun subscribeToRoom(
-            room: Room,
-            messageLimit: Int = 20,
-            listeners: RoomSubscriptionListeners,
-            cursorsListeners: CursorsSubscriptionListeners? = null
-    ){
+    @JvmOverloads
+    fun subscribeToRoom(
+        room: Room,
+        messageLimit: Int = 20,
+        listeners: RoomSubscriptionListeners,
+        cursorsListeners: CursorsSubscriptionListeners? = null
+    ) {
         val roomSubscription = RoomSubscription(this, room, userStore, listeners)
         apiInstance.subscribeResuming(
-                path = "/rooms/${room.id}?user_id=$id&message_limit=$messageLimit",
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                listeners = roomSubscription.subscriptionListeners
+            path = "/rooms/${room.id}?user_id=$id&message_limit=$messageLimit",
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            listeners = roomSubscription.subscriptionListeners
         )
         if (cursorsListeners == null) {
             return
         }
         val cursorsSubscription = CursorsSubscription(this, room, userStore, cursorsListeners)
         cursorsInstance.subscribeResuming(
-                path = "/cursors/0/rooms/${room.id}/",
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                listeners = cursorsSubscription.subscriptionListeners
+            path = "/cursors/0/rooms/${room.id}/",
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            listeners = cursorsSubscription.subscriptionListeners
         )
     }
 
     fun setCursor(
-            position: Int,
-            room: Room,
-            onCompleteListener: SetCursorListener,
-            onErrorListener: ErrorListener
+        position: Int,
+        room: Room,
+        onCompleteListener: SetCursorListener,
+        onErrorListener: ErrorListener
     ) {
         cursorsInstance.request(
-                options = RequestOptions(
-                        method = "PUT",
-                        path = "/cursors/0/rooms/${room.id}/users/$id",
-                        body = GSON.toJson(SetCursorRequest(position))
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { onCompleteListener.onSetCursor() },
-                onFailure = { onErrorListener.onError(it) }
+            options = RequestOptions(
+                method = "PUT",
+                path = "/cursors/0/rooms/${room.id}/users/$id",
+                body = GSON.toJson(SetCursorRequest(position))
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { onCompleteListener.onSetCursor() },
+            onFailure = { onErrorListener.onError(it) }
         )
     }
 
@@ -169,26 +172,26 @@ class CurrentUser(
         room.memberUserIds.forEach { userId ->
 
             userStore.findOrGetUser(
-                    id = userId,
-                    userListener = UserListener { user -> room.userStore().addOrMerge(user) },
-                    errorListener = ErrorListener {
-                        TODO("Not implemented")
+                id = userId,
+                userListener = UserListener { user -> room.userStore().addOrMerge(user) },
+                errorListener = ErrorListener {
+                    TODO("Not implemented")
 
-                    }
+                }
             )
         }
     }
 
     fun sendMessage(
-            roomId: Int,
-            text: String,
-            onCompleteListener: MessageSentListener,
-            onErrorListener: ErrorListener
+        roomId: Int,
+        text: String,
+        onCompleteListener: MessageSentListener,
+        onErrorListener: ErrorListener
     ) {
         async {
             val sendMesageRes = sendCompleteMessage(
-                    roomId = roomId,
-                    text = text
+                roomId = roomId,
+                text = text
             )
 
             when (sendMesageRes) {
@@ -203,115 +206,107 @@ class CurrentUser(
     }
 
     fun sendMessage(
-            roomId: Int,
-            text: String? = null,
-            attachment: GenericAttachment?,
-            onCompleteListener: MessageSentListener,
-            onErrorListener: ErrorListener
+        roomId: Int,
+        text: String? = null,
+        attachment: GenericAttachment,
+        onCompleteListener: MessageSentListener,
+        onErrorListener: ErrorListener
     ) {
         async {
-            var attachmentBody: AttachmentBody? = null
-
-            when (attachment) {
+            val attachmentBody = when (attachment) {
                 is DataAttachment -> {
                     val uploadRes = uploadFile(
-                            file = attachment.file,
-                            fileName = attachment.name,
-                            roomId = roomId
+                        file = attachment.file,
+                        fileName = attachment.name,
+                        roomId = roomId
                     )
 
                     when (uploadRes) {
-                        is Ok -> {
-                            attachmentBody = uploadRes.value
-                        }
-                        is Err -> {
-                            logger.error("Failed to upload file: ${uploadRes.error}")
-                            onErrorListener.onError(uploadRes.error)
-                            return@async
-                        }
+                        is Ok -> uploadRes.value
+                        is Err -> AttachmentBody.Failed(uploadRes.error)
                     }
                 }
-                is LinkAttachment -> {
-                    attachmentBody = AttachmentBody(attachment.link, attachment.type)
-                }
+                is LinkAttachment -> AttachmentBody.Resource(attachment.link, attachment.type)
+                is NoAttachment -> null
             }
 
-            val sendMesageRes = sendCompleteMessage(
+            if (attachmentBody is AttachmentBody.Failed) {
+                logger.error("Failed to upload file: ${attachmentBody.error}")
+                onErrorListener.onError(attachmentBody.error)
+            } else {
+                val sendMessageRes = sendCompleteMessage(
                     roomId = roomId,
                     text = text,
                     attachment = attachmentBody
-            )
+                )
 
-            when (sendMesageRes) {
-                is Ok -> {
-                    onCompleteListener.onMessage(sendMesageRes.value.messageId)
-                }
-                is Err -> {
-                    onErrorListener.onError(sendMesageRes.error)
+                when (sendMessageRes) {
+                    is Ok -> onCompleteListener.onMessage(sendMessageRes.value.messageId)
+                    is Err -> onErrorListener.onError(sendMessageRes.error)
                 }
             }
         }
     }
 
     private suspend fun sendCompleteMessage(
-            roomId: Int,
-            text: String? = null,
-            attachment: AttachmentBody? = null
+        roomId: Int,
+        text: String? = null,
+        attachment: AttachmentBody? = null
     ): Result<MessageSendingResponse, Error> = suspendCoroutine {
         val path = "/rooms/$roomId/messages"
-        val message = MessageRequest(text = text, userId = id, attachment = attachment)
+        val message = MessageRequest(text, id, attachment)
         apiInstance.request(
-                options = RequestOptions(
-                        method = "POST",
-                        path = path,
-                        body = GSON.toJson(message)
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { res ->
-                    val messageRes = GSON.fromJson<MessageSendingResponse>(res.body()!!.charStream(), MessageSendingResponse::class.java)
-                    it.resume(Ok(messageRes))
-                },
-                onFailure = { err -> it.resume(Err(err)) }
+            options = RequestOptions(
+                method = "POST",
+                path = path,
+                body = GSON.toJson(message)
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { res ->
+                val messageRes = GSON.fromJson<MessageSendingResponse>(res.body()!!.charStream(), MessageSendingResponse::class.java)
+                it.resume(Ok(messageRes))
+            },
+            onFailure = { err -> it.resume(Err(err)) }
         )
     }
 
     fun fetchAttachment(
-            attachmentUrl: String,
-            onCompleteListener: FetchedAttachmentListener,
-            onErrorListener: ErrorListener
+        attachmentUrl: String,
+        onCompleteListener: FetchedAttachmentListener,
+        onErrorListener: ErrorListener
     ) {
         filesInstance.request(
-                options = RequestOptions(
-                        method = "GET",
-                        destination = RequestDestination.Absolute(attachmentUrl)
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { response ->
-                    val fetchedAttachment = GSON.fromJson<FetchedAttachment>(response.body()!!.charStream(), FetchedAttachment::class.java)
-                    onCompleteListener.onFetch(fetchedAttachment)
-                },
-                onFailure = { error -> onErrorListener.onError(error) }
+            options = RequestOptions(
+                method = "GET",
+                destination = RequestDestination.Absolute(attachmentUrl)
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { response ->
+                val fetchedAttachment = GSON.fromJson<FetchedAttachment>(response.body()!!.charStream(), FetchedAttachment::class.java)
+                onCompleteListener.onFetch(fetchedAttachment)
+            },
+            onFailure = { error -> onErrorListener.onError(error) }
 
         )
     }
 
     private suspend fun uploadFile(
-            file: File,
-            fileName: String,
-            roomId: Int
+        file: File,
+        fileName: String,
+        roomId: Int
     ): Result<AttachmentBody, Error> = suspendCoroutine {
         filesInstance.upload(
-                path = "/rooms/$roomId/files/$fileName",
-                file = file,
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { res ->
-                    val attachmentBody = GSON.fromJson<AttachmentBody>(res.body()!!.charStream(), AttachmentBody::class.java)
-                    it.resume(Ok(attachmentBody))
-                },
-                onFailure = { err -> it.resume(Err(err)) }
+            path = "/rooms/$roomId/files/$fileName",
+            file = file,
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { res ->
+                val attachmentBody = GSON.fromJson<AttachmentBody>(res.body()!!.charStream(), AttachmentBody::class.java)
+                it.resume(Ok(attachmentBody))
+            },
+            onFailure = { err -> it.resume(Err(err)) }
         )
     }
 
@@ -322,11 +317,11 @@ class CurrentUser(
     fun removeUsers(roomId: Int, userIds: Array<String>, completeListener: OnCompleteListener, errorListener: ErrorListener) = addOrRemoveUsers("remove", roomId, userIds, completeListener, errorListener)
 
     private fun addOrRemoveUsers(
-            operation: String,
-            roomId: Int,
-            userIds: Array<String>,
-            completeListener: OnCompleteListener,
-            errorListener: ErrorListener){
+        operation: String,
+        roomId: Int,
+        userIds: Array<String>,
+        completeListener: OnCompleteListener,
+        errorListener: ErrorListener) {
 
         val data = object {
             val userIds = userIds
@@ -334,15 +329,15 @@ class CurrentUser(
 
         val path = "/rooms/$roomId/users/$operation"
         apiInstance.request(
-                options = RequestOptions(
-                        method = "PUT",
-                        path = path,
-                        body = GSON.toJson(data)
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { completeListener.onComplete() },
-                onFailure = { error -> errorListener.onError(error) }
+            options = RequestOptions(
+                method = "PUT",
+                path = path,
+                body = GSON.toJson(data)
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { completeListener.onComplete() },
+            onFailure = { error -> errorListener.onError(error) }
         )
     }
 
@@ -351,28 +346,28 @@ class CurrentUser(
      * */
 
     fun updateRoom(
-            room: Room,
-            name: String? = null,
-            isPrivate: Boolean? = null,
-            completeListener: OnCompleteListener,
-            errorListener: ErrorListener
-    ){
+        room: Room,
+        name: String? = null,
+        isPrivate: Boolean? = null,
+        completeListener: OnCompleteListener,
+        errorListener: ErrorListener
+    ) {
         val path = "/rooms/${room.id}"
         val data = UpdateRoomRequest(
-                    name = name ?: room.name,
-                    isPrivate =  isPrivate ?: room.isPrivate
+            name = name ?: room.name,
+            isPrivate = isPrivate ?: room.isPrivate
         )
 
         apiInstance.request(
-                options = RequestOptions(
-                        method = "PUT",
-                        path = path,
-                        body = GSON.toJson(data)
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { mainThread.post {  completeListener.onComplete() } },
-                onFailure = { error -> mainThread.post { errorListener.onError(error) } }
+            options = RequestOptions(
+                method = "PUT",
+                path = path,
+                body = GSON.toJson(data)
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { mainThread.post { completeListener.onComplete() } },
+            onFailure = { error -> mainThread.post { errorListener.onError(error) } }
         )
     }
 
@@ -385,21 +380,21 @@ class CurrentUser(
     fun deleteRoom(room: Room, completeListener: OnCompleteListener, errorListener: ErrorListener) = deleteRoom(room.id, completeListener, errorListener)
 
     fun deleteRoom(
-            roomId: Int,
-            completeListener: OnCompleteListener,
-            errorListener: ErrorListener
-    ){
+        roomId: Int,
+        completeListener: OnCompleteListener,
+        errorListener: ErrorListener
+    ) {
         val path = "/rooms/$roomId"
         apiInstance.request(
-                options = RequestOptions(
-                        method = "DELETE",
-                        path = path,
-                        body = ""
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { mainThread.post {  completeListener.onComplete() } },
-                onFailure = { error -> mainThread.post { errorListener.onError(error) } }
+            options = RequestOptions(
+                method = "DELETE",
+                path = path,
+                body = ""
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { mainThread.post { completeListener.onComplete() } },
+            onFailure = { error -> mainThread.post { errorListener.onError(error) } }
         )
     }
 
@@ -409,32 +404,32 @@ class CurrentUser(
     fun joinRoom(room: Room, completeListener: RoomListener, errorListener: ErrorListener) = joinRoom(room.id, completeListener, errorListener)
 
     fun joinRoom(
-            roomId: Int,
-            completeListener: RoomListener,
-            errorListener: ErrorListener
-    ){
-        val wrappedCompleteListener = RoomListener { room -> mainThread.post { completeListener.onRoom(room) }}
-        val wrappedErrorListener = ErrorListener { error -> mainThread.post { errorListener.onError(error) }}
+        roomId: Int,
+        completeListener: RoomListener,
+        errorListener: ErrorListener
+    ) {
+        val wrappedCompleteListener = RoomListener { room -> mainThread.post { completeListener.onRoom(room) } }
+        val wrappedErrorListener = ErrorListener { error -> mainThread.post { errorListener.onError(error) } }
 
         val path = HttpUrl.parse("https://pusherplatform.io")!!.newBuilder().addPathSegments("/users/$id/rooms/$roomId/join").build().encodedPath()
 
         apiInstance.request(
-                options = RequestOptions(
-                        method = "POST",
-                        path = path,
-                        body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { response ->
+            options = RequestOptions(
+                method = "POST",
+                path = path,
+                body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { response ->
 
-                    val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
-                    roomStore.addOrMerge(room)
-                    populateRoomUserStore(room)
-                    wrappedCompleteListener.onRoom(room)
+                val room = GSON.fromJson<Room>(response.body()!!.charStream(), Room::class.java)
+                roomStore.addOrMerge(room)
+                populateRoomUserStore(room)
+                wrappedCompleteListener.onRoom(room)
 
-                },
-                onFailure = { error -> wrappedErrorListener.onError(error) }
+            },
+            onFailure = { error -> wrappedErrorListener.onError(error) }
         )
     }
 
@@ -445,58 +440,61 @@ class CurrentUser(
     fun leaveRoom(room: Room, completeListener: OnCompleteListener, errorListener: ErrorListener) = leaveRoom(room.id, completeListener, errorListener)
 
     fun leaveRoom(
-            roomId: Int,
-            completeListener: OnCompleteListener,
-            errorListener: ErrorListener
-    ){
+        roomId: Int,
+        completeListener: OnCompleteListener,
+        errorListener: ErrorListener
+    ) {
         val path = HttpUrl.parse("https://pusherplatform.io")!!.newBuilder().addPathSegments("/users/$id/rooms/$roomId/leave").build().encodedPath()
 
         apiInstance.request(
-                options = RequestOptions(
-                        method = "POST",
-                        path = path,
-                        body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
-                ),
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                onSuccess = { completeListener.onComplete() },
-                onFailure = { error -> errorListener.onError(error) }
+            options = RequestOptions(
+                method = "POST",
+                path = path,
+                body = "" //TODO: this is a horrible OKHTTP hack - POST is required to have a body.
+            ),
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            onSuccess = { completeListener.onComplete() },
+            onFailure = { error -> errorListener.onError(error) }
         )
     }
 
     fun establishPresenceSubscription(listeners: ThreadedUserSubscriptionListeners) {
 
         presenceSubscription = PresenceSubscription(
-                instance = apiInstance,
-                path = "/users/$id/presence",
-                listeners = listeners,
-                tokenProvider = tokenProvider,
-                tokenParams = tokenParams,
-                userStore = userStore,
-                logger = logger
+            instance = apiInstance,
+            path = "/users/$id/presence",
+            listeners = listeners,
+            tokenProvider = tokenProvider,
+            tokenParams = tokenParams,
+            userStore = userStore,
+            logger = logger
         )
     }
 }
 
 data class MessageRequest(val text: String? = null, val userId: String, val attachment: AttachmentBody? = null)
 
-data class AttachmentBody(val resourceLink: String, val type: String)
+sealed class AttachmentBody {
+    data class Resource(val resourceLink: String, val type: String) : AttachmentBody()
+    data class Failed(val error: Error) : AttachmentBody()
+}
 
 data class SetCursorRequest(val position: Int)
 
 data class MessageSendingResponse(val messageId: Int)
 
 data class RoomCreateRequest(
-        val name: String,
-        val private: Boolean,
-        val createdById: String,
-        var userIds: Array<String>? = null
+    val name: String,
+    val private: Boolean,
+    val createdById: String,
+    var userIds: Array<String>? = null
 )
 
 data class FetchedAttachment(
-        val file: FetchedAttachmentFile,
-        @SerializedName("resource_link") val link: String,
-        val ttl: Double
+    val file: FetchedAttachmentFile,
+    @SerializedName("resource_link") val link: String,
+    val ttl: Double
 )
 
 data class FetchedAttachmentFile(val bytes: Int, val lastModified: Double, val name: String)


### PR DESCRIPTION
Quick fix to make the demo app not crash. `ChatRoomActivity` is sending a message without an attachment that makes the demo crash.

```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: 
method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter attachment
  at com.pusher.chatkit.CurrentUser.sendMessage(CurrentUser.kt:0)
  at com.pusher.chatkit.sample.ChatRoomActivity$3$1.onCurrentUser(ChatRoomActivity.java:304)
  at com.pusher.chatkit.sample.ChatApplication.getCurrentUser(ChatApplication.java:115)
  at com.pusher.chatkit.sample.ChatRoomActivity$3.onClick(ChatRoomActivity.java:299)
```