### PR TITLE
Moved app requirements to ~/.gradle/gradle.properties

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,30 @@ android {
     }
 }
 
+def buildConfigStringFields(variant, Map<String, String> values) {
+    def invalid = []
+    values.forEach { name, key ->
+        if(project.hasProperty(key)) {
+            variant.buildConfigField "String", name, "\"${project.property(key)}\""
+        } else {
+            invalid += key
+        }
+    }
+    if (!invalid.empty) {
+        throw new StopActionException("Please set value(s) for ${invalid.join(", ")} in ~/.gradle/gradle.properties")
+    }
+}
+
+android.applicationVariants.all { variant ->
+    buildConfigStringFields(variant,
+        [
+            "INSTANCE_LOCATOR" : "pusher_instance_locator",
+            "TOKEN_PROVIDER_ENDPOINT" : "pusher_token_provider_url",
+            "USER_ID" : "pusher_user_name"
+        ]
+    )
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'

--- a/app/src/main/java/com/pusher/chatkit/sample/ChatApplication.java
+++ b/app/src/main/java/com/pusher/chatkit/sample/ChatApplication.java
@@ -14,9 +14,6 @@ import elements.Error;
 import timber.log.Timber;
 
 public class ChatApplication extends Application {
-    private static final String INSTANCE_LOCATOR = "YOUR_INSTANCE_LOCATOR";
-    private static final String TOKEN_PROVIDER_ENDPOINT = "YOUR_TEST_TOKEN_PROVIDER_URL";
-    private static final String USER_ID = "YOUR_CREATED_USER_ID";
 
     private ChatManager chatManager;
     private CurrentUser currentUser;
@@ -27,11 +24,11 @@ public class ChatApplication extends Application {
         super.onCreate();
         Timber.plant(new Timber.DebugTree());
 
-        ChatkitTokenProvider tokenProvider = new ChatkitTokenProvider(TOKEN_PROVIDER_ENDPOINT);
+        ChatkitTokenProvider tokenProvider = new ChatkitTokenProvider(BuildConfig.TOKEN_PROVIDER_ENDPOINT);
 
         chatManager = new ChatManager.Builder()
-                .instanceLocator(INSTANCE_LOCATOR)
-                .userId(USER_ID)
+                .instanceLocator(BuildConfig.INSTANCE_LOCATOR)
+                .userId(BuildConfig.USER_ID)
                 .context(getApplicationContext())
                 .tokenProvider(tokenProvider)
                 .build();


### PR DESCRIPTION
Move the config dependencies from code to gradle properties.

If the values are not set this error will show up when syncing the project:

```
Error:(32, 0) Please set value(s) for pusher_instance_locator, pusher_token_provider_url, pusher_user_name in ~/.gradle/gradle.properties
```

This removes the need to have uncommitted changes locally to run the example.