### PR TITLE
Upgrade gradle and dependency version references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,17 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.2.30'
+        kotlin_version = '1.2.31'
+        coroutines_version = '0.22.1'
+        android_gradle_version = '3.1.1'
+        android_support_version = '27.1.1'
+        android_arch_version = '1.1.1'
+        mockito_version = '2.10.0'
+        constraints_layout_version = '1.1.0'
+        espresso_version = '3.0.1'
+        espresso_runner_version = '1.0.1'
+        junit_legacy_version = '4.12'
+        pusher_platform_version = '0.3.0'
     }
     repositories {
         google()
@@ -10,9 +20,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath "com.android.tools.build:gradle:$android_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:bintray-release:0.8.0'
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0'
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.0.31'
     }
 }
 

--- a/chatkit/build.gradle
+++ b/chatkit/build.gradle
@@ -33,20 +33,20 @@ kotlin {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation "com.android.support:appcompat-v7:$android_support_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.22.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     if (rootProject.properties.containsKey("pusher_platform_local")) {
         api project(':pusher-platform-local')
     } else {
-        api 'com.pusher:pusher-platform-android:0.3.0'
+        api "com.pusher:pusher-platform-android:$pusher_platform_version"
     }
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
+    testImplementation "junit:junit:$junit_legacy_version"
+    androidTestImplementation("com.android.support.test.espresso:espresso-core:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 }

--- a/demos/kotlin-app/build.gradle
+++ b/demos/kotlin-app/build.gradle
@@ -58,18 +58,18 @@ androidExtensions {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.22.1"
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation 'com.android.support:design:27.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    implementation "android.arch.lifecycle:common:1.1.1"
-    implementation 'com.android.support:customtabs:27.1.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    implementation "com.android.support:appcompat-v7:$android_support_version"
+    implementation "com.android.support:design:$android_support_version"
+    implementation "com.android.support.constraint:constraint-layout:$constraints_layout_version"
+    implementation "android.arch.lifecycle:extensions:$android_arch_version"
+    implementation "android.arch.lifecycle:common:$android_arch_version"
+    implementation "com.android.support:customtabs:$android_support_version"
     implementation project(':chatkit')
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation "junit:junit:$junit_legacy_version"
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation "com.android.support.test:runner:$espresso_runner_version"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:$espresso_version"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,5 @@ if (properties.containsKey("pusher_platform_local")) {
     def localPath = properties["pusher_platform_local"]
     injectProject(':pusher-platform-local', "$localPath/library")
     injectProject(':library-core', "$localPath/library-core")
+    injectProject(':test-common', "$localPath/test-common")
 }


### PR DESCRIPTION
Small tweaks to Gradle:

 - Upgrade to 4.6
 - move versions to global version
 - attached requirements for incoming changes from the platform lib (`:test-common`)