### PR TITLE
Deployment Bug

### DIFF
--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -79,7 +79,7 @@ publishing {
                 //Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
                 configurations.implementation.allDependencies.each {
                     def dependencyNode = dependenciesNode.appendNode('dependency')
-                    if(it.name == "pusher-platform-core") {
+                    if(it.name == "chatkit-core") {
                         dependencyNode.appendNode('groupId', GROUP)
                         dependencyNode.appendNode('artifactId', it.name)
                         dependencyNode.appendNode('version', VERSION_NAME)


### PR DESCRIPTION
The pom file we have delivered with the current release points to this dependency:
```
chatkit-parent:chatkit-core:unspecified
```
But it should point to this other one: 
```
com.pusher:chatkit-core:0.2.0
```
The publication script was looking for the incorrect module.

@hamchapman There is no need to increment the version, we can do an overriding release.