### PR TITLE
onNewMessage rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-android/compare/0.2.4...HEAD)
 
+### Changed
+
+- Renamed `onNewMessage` `RoomSubscriptionListeners` function to `onMessage` to make it clearer that it is the function that gets called when a new message is received over the room subscription, which includes historical messages upon initial subscription success
+- Renamed the `NewMessage` `RoomSubscriptionEvent` to `Message`, for the same reasons as the point above
+
 ## [0.2.4](https://github.com/pusher/chatkit-android/compare/0.2.3...0.2.4) - 2018-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Using `RoomSubscriptionListeners`:
 currentUser.subscribeToRoom(
   roomId = someroomId,
   listeners = Roomsubscription(
-    onNewMessage = { message -> toast("${message.userId} says: ${message.text}") },
+    onMessage = { message -> toast("${message.userId} says: ${message.text}") },
     onErrorOccurred = { error -> toast("Oops something bad happened: $error") }
   ),
   messageLimit = 10 // Optional, 10 by default
@@ -504,7 +504,7 @@ currentUser.subscribeToRoom(
     messageLimit = 10 // Optional, 10 by default
 ) { event ->
   when(event) {
-    is NewMessage -> toast("${event.message.userId} says: ${event.message.text}")
+    is Message -> toast("${event.message.userId} says: ${event.message.text}")
     is ErrorOccurred -> toast("Oops something bad happened: ${event.error}")
   }
 }
@@ -512,7 +512,7 @@ currentUser.subscribeToRoom(
 
 **Note:** Subscribing implicitly joins a room if you aren’t already a member. Subscribing to the same room twice will cause the existing subscription to be cancelled and replaced by the new one.
 
-By default when you subscribe to a room you will receive up to the 10 most recent messages that have been added to the room. The number of recent messages to fetch can be configured by setting the `messageLimit` parameter`. These recent messages will be passed to the `onNewMessage` callback (or as `NewMessage` event) in the order they were sent, just as if they were being sent for the first time.
+By default when you subscribe to a room you will receive up to the 10 most recent messages that have been added to the room. The number of recent messages to fetch can be configured by setting the `messageLimit` parameter`. These recent messages will be passed to the `onMessage` callback (or as `Message` event) in the order they were sent, just as if they were being sent for the first time.
 
 ### Room subscription events
 
@@ -520,7 +520,7 @@ This is the full list of available events from a room subscription:
 
  | Event             | Properties   | Description                                           |
  |-------------------|--------------|-------------------------------------------------------|
- | NewMessage        | Message      | A new message has been added to the room.             |
+ | Message        | Message      | A new message has been added to the room.             |
  | UserStartedTyping | User         | User has started typing                               |
  | UserStoppedTyping | User         | User has stopped typing                               |
  | UserJoined        | Int (userId) | User has joined the room                              |

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerSpek.kt
@@ -75,7 +75,7 @@ class ChatManagerSpek : Spek({
             var messageReceived by FutureValue<Message>()
 
             pusherino.assumeSuccess().subscribeToRoom(room, RoomSubscriptionListeners(
-                onNewMessage = { message -> messageReceived = message },
+                onMessage = { message -> messageReceived = message },
                 onErrorOccurred = { e -> error("error: $e") }
             ))
 
@@ -176,7 +176,7 @@ class ChatManagerSpek : Spek({
                 onUserCameOnline = { actual += "onUserCameOnline" to it },
                 onUserStartedTyping = { actual += "onUserStartedTyping" to it },
                 onUserWentOffline = { actual += "onUserWentOffline" to it },
-                onNewMessage = { actual += "onNewMessage" to it },
+                onMessage = { actual += "onMessage" to it },
                 onUserJoined = { actual += "onUserJoined" to it },
                 onUserLeft = { actual += "onUserLeft" to it }
             ).toCallback()
@@ -190,7 +190,7 @@ class ChatManagerSpek : Spek({
             consume(RoomSubscriptionEvent.RoomDeleted(roomId))
             consume(RoomSubscriptionEvent.NewReadCursor(cursor))
             consume(RoomSubscriptionEvent.ErrorOccurred(error))
-            consume(RoomSubscriptionEvent.NewMessage(message))
+            consume(RoomSubscriptionEvent.Message(message))
 
             assertThat(actual).containsExactly(
                 "onUserStartedTyping" to user,
@@ -202,7 +202,7 @@ class ChatManagerSpek : Spek({
                 "onRoomDeleted" to roomId,
                 "onNewReadCursor" to cursor,
                 "onErrorOccurred" to error,
-                "onNewMessage" to message
+                "onMessage" to message
             )
 
         }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/MessagesSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/MessagesSpek.kt
@@ -160,7 +160,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomSubscriptionEvent.NewMessage -> receivedMessage = event.message
+                    is RoomSubscriptionEvent.Message -> receivedMessage = event.message
                 }
             }
 
@@ -187,7 +187,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomSubscriptionEvent.NewMessage -> receivedMessage = event.message
+                    is RoomSubscriptionEvent.Message -> receivedMessage = event.message
                 }
             }
 
@@ -216,7 +216,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomSubscriptionEvent.NewMessage -> receivedMessage = event.message
+                    is RoomSubscriptionEvent.Message -> receivedMessage = event.message
                 }
             }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscription.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscription.kt
@@ -64,11 +64,11 @@ internal class RoomSubscription(
     private fun User.isInRoom() = chatManager.roomService.fetchRoomBy(id, roomId).mapResult { true }.wait().recover { false }
 
     private fun ChatEvent.toRoomEvent() : RoomSubscriptionEvent = when(eventName) {
-        "new_message" -> data.toNewMessage()
+        "new_message" -> data.toMessage()
         else -> ErrorOccurred(Errors.other("Wrong event type: $eventName")).asSuccess<RoomSubscriptionEvent, Error>()
     }.recover { error -> ErrorOccurred(error) }
 
-    private fun JsonElement.toNewMessage(): Result<RoomSubscriptionEvent, Error> = parseAs<Message>()
+    private fun JsonElement.toMessage(): Result<RoomSubscriptionEvent, Error> = parseAs<Message>()
         .map { message ->
             if (message.attachment != null) {
                 val queryParamsMap: Map<String, String> = (URL(message.attachment.link).query?.split("&") ?: emptyList())
@@ -83,7 +83,7 @@ internal class RoomSubscription(
                     onFailure = {},
                     onSuccess = { message.user = it }
             )
-            NewMessage(message)
+            Message(message)
 
         }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionListeners.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionListeners.kt
@@ -1,7 +1,7 @@
 package com.pusher.chatkit.rooms
 
 import com.pusher.chatkit.cursors.Cursor
-import com.pusher.chatkit.messages.Message
+import com.pusher.chatkit.messages.Message as ChatkitMessage
 import com.pusher.chatkit.users.User
 import elements.Error
 
@@ -9,7 +9,7 @@ import elements.Error
  * Used in [com.pusher.chatkit.CurrentUser] to register for room events.
  */
 data class RoomSubscriptionListeners @JvmOverloads constructor(
-    val onNewMessage: (Message) -> Unit = {},
+    val onMessage: (ChatkitMessage) -> Unit = {},
     val onUserStartedTyping: (User) -> Unit = {},
     val onUserStoppedTyping: (User) -> Unit = {},
     val onUserJoined: (User) -> Unit = {},
@@ -32,7 +32,7 @@ typealias RoomSubscriptionConsumer = (RoomSubscriptionEvent) -> Unit
  */
 internal fun RoomSubscriptionListeners.toCallback(): RoomSubscriptionConsumer = { event ->
     when(event) {
-        is RoomSubscriptionEvent.NewMessage -> onNewMessage(event.message)
+        is RoomSubscriptionEvent.Message -> onMessage(event.message)
         is RoomSubscriptionEvent.UserStartedTyping -> onUserStartedTyping(event.user)
         is RoomSubscriptionEvent.UserStoppedTyping -> onUserStoppedTyping(event.user)
         is RoomSubscriptionEvent.UserJoined -> onUserJoined(event.user)
@@ -50,7 +50,7 @@ internal fun RoomSubscriptionListeners.toCallback(): RoomSubscriptionConsumer = 
  * Same as [RoomSubscriptionListeners] but using events instead of individual listeners.
  */
 sealed class RoomSubscriptionEvent {
-    data class NewMessage(val message: Message) : RoomSubscriptionEvent()
+    data class Message(val message: ChatkitMessage) : RoomSubscriptionEvent()
     data class UserStartedTyping(val user: User) : RoomSubscriptionEvent()
     data class UserStoppedTyping(val user: User) : RoomSubscriptionEvent()
     data class UserJoined(val user: User) : RoomSubscriptionEvent()


### PR DESCRIPTION
I based it on api-v2 but pretty much all of the tests seem to currently be broken on that branch.

The only annoyance with this PR is that I needed to alias the `Message` import in `RoomSubscriptionListeners` otherwise the compiler was getting confused with type names: https://github.com/pusher/chatkit-android/compare/api-v2...on-message-rename?expand=1#diff-07fd3b3985b83e5f721b801373d2bba5R4