### PR TITLE
Rename NewMessage -> Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Using `RoomListeners`:
 currentUser.subscribeToRoom(
   roomId = someroomId,
   listeners = RoomListeners(
-    onNewMessage = { message -> toast("${message.userId} said: ${message.text}") },
+    onMessage = { message -> toast("${message.userId} said: ${message.text}") },
     onErrorOccurred = { error -> toast("Oops something bad happened: $error") }
   ),
   messageLimit = 10 // Optional, 10 by default
@@ -347,7 +347,7 @@ currentUser.subscribeToRoom(
     messageLimit = 10 // Optional, 10 by default
 ) { event ->
   when (event) {
-    is NewMessage -> toast("${event.message.userId} said: ${event.message.text}")
+    is Message -> toast("${event.message.userId} said: ${event.message.text}")
     is ErrorOccurred -> toast("Oops something bad happened: ${event.error}")
   }
 }
@@ -360,9 +360,9 @@ cancelled and replaced by the new one.
 By default when you subscribe to a room you will receive up to the 10 most
 recent messages that have been added to the room. The number of recent messages
 to fetch can be configured by setting the `messageLimit` parameter. These
-recent messages will be passed to the `onNewMessage` callback (or as
-`NewMessage` event) in the order they were sent, just as if they were being
-sent for the first time.
+recent messages will be passed to the `onMessage` callback (or as `Message`
+event) in the order they were sent, just as if they were being sent for the
+first time.
 
 #### Room events
 
@@ -373,7 +373,7 @@ the handler is registered for.
 
  | Event             | Properties   | Description                                           |
  |-------------------|--------------|-------------------------------------------------------|
- | NewMessage        | Message      | A new message has been added to the room.             |
+ | Message           | Message      | A new message has been added to the room.             |
  | UserStartedTyping | User         | User has started typing                               |
  | UserStoppedTyping | User         | User has stopped typing                               |
  | UserJoined        | Int (userId) | User has joined the room                      TODO    |

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerSpek.kt
@@ -73,7 +73,7 @@ class ChatManagerSpek : Spek({
             var messageReceived by FutureValue<Message>()
 
             pusherino.assumeSuccess().subscribeToRoom(room, RoomListeners(
-                onNewMessage = { message -> messageReceived = message },
+                onMessage = { message -> messageReceived = message },
                 onErrorOccurred = { e -> error("error: $e") }
             ))
 
@@ -166,7 +166,7 @@ class ChatManagerSpek : Spek({
                 onUserCameOnline = { actual += "onUserCameOnline" to it },
                 onUserStartedTyping = { actual += "onUserStartedTyping" to it },
                 onUserWentOffline = { actual += "onUserWentOffline" to it },
-                onNewMessage = { actual += "onNewMessage" to it },
+                onMessage = { actual += "onMessage" to it },
                 onUserJoined = { actual += "onUserJoined" to it },
                 onUserLeft = { actual += "onUserLeft" to it }
             ).toCallback()
@@ -180,7 +180,7 @@ class ChatManagerSpek : Spek({
             consume(RoomEvent.RoomDeleted(roomId))
             consume(RoomEvent.NewReadCursor(cursor))
             consume(RoomEvent.ErrorOccurred(error))
-            consume(RoomEvent.NewMessage(message))
+            consume(RoomEvent.Message(message))
 
             assertThat(actual).containsExactly(
                 "onUserStartedTyping" to user,
@@ -192,7 +192,7 @@ class ChatManagerSpek : Spek({
                 "onRoomDeleted" to roomId,
                 "onNewReadCursor" to cursor,
                 "onErrorOccurred" to error,
-                "onNewMessage" to message
+                "onMessage" to message
             )
         }
     }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/MessagesSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/MessagesSpek.kt
@@ -156,7 +156,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomEvent.NewMessage -> receivedMessage = event.message
+                    is RoomEvent.Message -> receivedMessage = event.message
                 }
             }
 
@@ -183,7 +183,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomEvent.NewMessage -> receivedMessage = event.message
+                    is RoomEvent.Message -> receivedMessage = event.message
                 }
             }
 
@@ -212,7 +212,7 @@ class MessagesSpek : Spek({
 
             pusherino.subscribeToRoom(pusherino.generalRoom) { event ->
                 when (event) {
-                    is RoomEvent.NewMessage -> receivedMessage = event.message
+                    is RoomEvent.Message -> receivedMessage = event.message
                 }
             }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomEvent.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomEvent.kt
@@ -16,7 +16,7 @@ typealias RoomConsumer = (RoomEvent) -> Unit
  * RoomSubscription.
  */
 sealed class RoomEvent {
-    data class NewMessage(val message: Message) : RoomEvent()
+    data class Message(val message: com.pusher.chatkit.messages.Message) : RoomEvent()
     data class UserStartedTyping(val user: User) : RoomEvent()
     data class UserStoppedTyping(val user: User) : RoomEvent()
     data class UserJoined(val user: User) : RoomEvent()
@@ -36,7 +36,7 @@ sealed class RoomEvent {
  * consuming RoomEvents.
  */
 data class RoomListeners @JvmOverloads constructor(
-        val onNewMessage: (Message) -> Unit = {},
+        val onMessage: (Message) -> Unit = {},
         val onUserStartedTyping: (User) -> Unit = {},
         val onUserStoppedTyping: (User) -> Unit = {},
         val onUserJoined: (User) -> Unit = {},
@@ -51,7 +51,7 @@ data class RoomListeners @JvmOverloads constructor(
 
 internal fun RoomListeners.toCallback(): RoomConsumer = { event ->
     when(event) {
-        is RoomEvent.NewMessage -> onNewMessage(event.message)
+        is RoomEvent.Message -> onMessage(event.message)
         is RoomEvent.UserStartedTyping -> onUserStartedTyping(event.user)
         is RoomEvent.UserStoppedTyping -> onUserStoppedTyping(event.user)
         is RoomEvent.UserJoined -> onUserJoined(event.user)

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionGroup.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionGroup.kt
@@ -145,7 +145,7 @@ class RoomSubscriptionGroup(
                     is RoomSubscriptionEvent.NewMessage ->
                         userService.fetchUserBy(event.message.userId).map { user ->
                             event.message.user = user
-                            RoomEvent.NewMessage(event.message) as RoomEvent
+                            RoomEvent.Message(event.message) as RoomEvent
                         }.recover {
                             RoomEvent.ErrorOccurred(it)
                         }


### PR DESCRIPTION
Motivated because the messages passed to these listeners may not be
strictly *new*. They might be part of the last `x` historic messages
fetched on subscription start, for example.