### PR TITLE
Remove `userId` constructor argument from TokenProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-android/compare/1.0.2...HEAD)
 
+### Breaking
+
+- Removed the `userId` constructor argument in favour of newly added `queryParams` argument
+  to keep consistent with other client libraries.
+- Removed the `authData` constructor argument to be in line with other client SDK's.
+- Both of the above are **breaking** changes.
+
 ## [1.0.2](https://github.com/pusher/chatkit-android/compare/1.0.1...1.0.2)
 
 ### Fixed

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
@@ -31,7 +31,7 @@ class SynchronousChatManager constructor(
     internal val dependencies: ChatkitDependencies
 ) {
     private val tokenProvider: TokenProvider = DebounceTokenProvider(
-            dependencies.tokenProvider.also { (it as? ChatkitTokenProvider)?.userId = userId }
+            dependencies.tokenProvider.also { (it as? ChatkitTokenProvider)?.queryParams?.put("user_id", userId) }
     )
 
     private val logger = dependencies.logger

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/ChatkitTokenProviderTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/ChatkitTokenProviderTest.kt
@@ -23,7 +23,7 @@ import java.util.*
 
 private val testProvider = ChatkitTokenProvider(
     endpoint = "https://localhost",
-    userId = "pusherino"
+    queryParams = mutableMapOf("user_id" to "pusherino")
 )
 
 internal class ChatkitTokenProviderTest : Spek({
@@ -64,7 +64,7 @@ internal class ChatkitTokenProviderTest : Spek({
 
         it("provides CustomData as part of request") {
             val provider = testProvider.copy(
-                authData = mapOf("key" to "value"),
+                queryParams = mutableMapOf("key" to "value"),
                 client = mock {
                     newCall(argThat {
                         it.url().toString() == "https://localhost/?user_id=pusherino" &&


### PR DESCRIPTION
- Also remove `authData` and introduce `queryParams`

Notes:
- The JS library also includes a `headers` parameter in addition to `queryParams`. Do we want something like that?
- Alternatively, we could do something like beams do and write a custom `AuthData` class that accepts both query params and headers and attaches them to requests accordingly.