### PR TITLE
Hook in to the Android lifecycle for presence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         espresso_version = '3.0.1'
         espresso_runner_version = '1.0.1'
         junit_legacy_version = '4.12'
-        pusher_platform_version = '1.0.2'
+        pusher_platform_version = '1.0.3'
         dokka_version = '0.9.17'
 
         bintray_user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')

--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -67,6 +67,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
     api 'com.github.pusher:push-notifications-android:add-users-support-SNAPSHOT'
 }
 

--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -44,7 +44,6 @@ android {
             details 'tree'
         }
     }
-
 }
 
 dependencies {

--- a/chatkit-android/src/main/kotlin/com/pusher/chatkit/AndroidAppHooks.kt
+++ b/chatkit-android/src/main/kotlin/com/pusher/chatkit/AndroidAppHooks.kt
@@ -1,0 +1,22 @@
+package com.pusher.chatkit
+
+import android.arch.lifecycle.*
+
+class AndroidAppHooks : AppHooks {
+    override fun register(appOpened: () -> Unit, appClosed: () -> Unit) {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+                object : LifecycleObserver {
+                    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+                    fun onStart(source: LifecycleOwner) {
+                        appOpened.invoke()
+                    }
+
+                    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+                    fun onStop(source: LifecycleOwner) {
+                        appClosed.invoke()
+                    }
+                }
+        )
+    }
+}
+

--- a/chatkit-android/src/main/kotlin/com/pusher/chatkit/AndroidChatkitDependencies.kt
+++ b/chatkit-android/src/main/kotlin/com/pusher/chatkit/AndroidChatkitDependencies.kt
@@ -2,9 +2,7 @@ package com.pusher.chatkit
 
 import android.content.Context
 import com.pusher.SdkInfo
-import com.pusher.chatkit.pushnotifications.PushNotificationsFactory
 import com.pusher.platform.AndroidDependencies
-import com.pusher.platform.MediaTypeResolver
 import com.pusher.platform.PlatformDependencies
 import com.pusher.platform.logger.Logger
 import com.pusher.platform.tokenProvider.TokenProvider
@@ -14,21 +12,21 @@ import okhttp3.OkHttpClient
  * [ChatkitDependencies] implementation for Android using [AndroidDependencies] to fulfil [PlatformDependencies].
  */
 data class AndroidChatkitDependencies @JvmOverloads constructor(
-    val context: Context,
-    override val tokenProvider: TokenProvider,
-    override val okHttpClient: OkHttpClient? = null,
-    private val platformDependencies: PlatformDependencies = AndroidDependencies(),
-    override val logger: Logger = platformDependencies.logger
+        private val context: Context,
+        override val tokenProvider: TokenProvider,
+        override val okHttpClient: OkHttpClient? = null,
+        private val platformDependencies: PlatformDependencies = AndroidDependencies(),
+        override val logger: Logger = platformDependencies.logger
 ) : ChatkitDependencies {
 
-    override val mediaTypeResolver: MediaTypeResolver = platformDependencies.mediaTypeResolver
-    override val sdkInfo: SdkInfo = chatkitSdkInfo
-    override val pushNotifications: PushNotificationsFactory = BeamsPushNotificationsFactory(context)
-}
+    override val mediaTypeResolver = platformDependencies.mediaTypeResolver
+    override val pushNotifications = BeamsPushNotificationsFactory(context)
+    override val appHooks = AndroidAppHooks()
 
-private val chatkitSdkInfo get() = SdkInfo(
-    product = "Chatkit",
-    sdkVersion = BuildConfig.VERSION_NAME,
-    platform = "Android",
-    language = "Kotlin/Java"
-)
+    override val sdkInfo = SdkInfo(
+            product = "Chatkit",
+            sdkVersion = BuildConfig.VERSION_NAME,
+            platform = "Android",
+            language = "Kotlin/Java"
+    )
+}

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerFixtures.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerFixtures.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit
 
 import com.pusher.SdkInfo
 import com.pusher.chatkit.pushnotifications.PushNotificationsFactory
+import com.pusher.chatkit.test.NoAppHooks
 import com.pusher.chatkit.test.NoPushNotificationFactory
 import com.pusher.chatkit.test.insecureOkHttpClient
 import com.pusher.platform.MediaTypeResolver
@@ -50,6 +51,7 @@ class TestChatkitDependencies(
         }
     }.build()
     override val pushNotifications = NoPushNotificationFactory()
+    override val appHooks = NoAppHooks()
 }
 
 val SynchronousCurrentUser.generalRoom

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/test/NoAppHooks.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/test/NoAppHooks.kt
@@ -1,0 +1,9 @@
+package com.pusher.chatkit.test
+
+import com.pusher.chatkit.AppHooks
+
+class NoAppHooks : AppHooks {
+    override fun register(appOpened: () -> Unit, appClosed: () -> Unit) {
+        // No op
+    }
+}

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/AppHooks.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/AppHooks.kt
@@ -1,0 +1,8 @@
+package com.pusher.chatkit
+
+interface AppHooks {
+    fun register(
+            appOpened: () -> Unit,
+            appClosed: () -> Unit
+    )
+}

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/ChatkitDependencies.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/ChatkitDependencies.kt
@@ -8,5 +8,6 @@ import okhttp3.OkHttpClient
 interface ChatkitDependencies : PlatformDependencies {
     val tokenProvider: TokenProvider
     val okHttpClient : OkHttpClient?
+    val appHooks: AppHooks
     val pushNotifications: PushNotificationsFactory
 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
@@ -16,6 +16,7 @@ import com.pusher.chatkit.users.UserService
 import com.pusher.chatkit.users.UserSubscriptionEvent
 import com.pusher.chatkit.users.UserSubscriptionEventParser
 import com.pusher.platform.Instance
+import com.pusher.platform.Locator
 import com.pusher.platform.SubscriptionListeners
 import com.pusher.platform.tokenProvider.TokenProvider
 import com.pusher.util.Result
@@ -42,7 +43,7 @@ class SynchronousChatManager constructor(
     private val filesClient = createPlatformClient(InstanceType.FILES)
 
     private val beams = dependencies.pushNotifications.newBeams(
-            instanceLocator,
+            Locator(instanceLocator).id,
             BeamsTokenProviderService(createPlatformClient(InstanceType.BEAMS_TOKEN_PROVIDER))
     )
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
@@ -107,6 +107,11 @@ class SynchronousChatManager constructor(
     fun connect(consumer: ChatManagerEventConsumer = {}): Result<SynchronousCurrentUser, Error> {
         eventConsumers += consumer
 
+        dependencies.appHooks.register(
+                presenceService::goOffline,
+                presenceService::goOnline
+        )
+
         userSubscription = ResolvableSubscription(
                 client = chatkitClient,
                 path = "users",
@@ -122,7 +127,6 @@ class SynchronousChatManager constructor(
         cursorSubscription =
                 cursorService.subscribeForUser(userId, this::consumeCursorSubscriptionEvent)
 
-        // Await connection of both subscriptions
         userSubscription.await()
         cursorSubscription.await()
 


### PR DESCRIPTION
We want to tear down the presence registration immediately if the app is
backgrounded, because they're not really "present" any more.

We leave the other subscriptions up for now, because this will make
switching back to the app much quicker.