### PR TITLE
Initial state reconciliation

### DIFF
--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -39,8 +39,6 @@ class RoomSpek : Spek({
             val alice = chatFor(ALICE).connect().assumeSuccess()
 
             alice.subscribeToRoom(alice.generalRoom) { event ->
-                // TODO this represents a change in behaviour
-                // Previously we didn't report users joined and left from the initial state
                 if (event is RoomEvent.UserJoined && event.user.id == PUSHERINO) userJoined = event.user
             }
 

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/_ChatManager.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/_ChatManager.kt
@@ -30,12 +30,9 @@ fun <A> SynchronousChatManager.subscribeRoomFor(roomName: String, block: (RoomEv
  */
 fun <A> SynchronousCurrentUser.subscribeRoomFor(roomName: String, block: (RoomEvent) -> A?): FutureValue<A> {
     val futureValue = FutureValue<A>()
-    var ready by FutureValue<Any>()
     val room = rooms.first { it.name == roomName }
     subscribeToRoom(room) {
-        if (it is RoomEvent.InitialReadCursors) ready = it
         (block(it))?.let { futureValue.set(it) }
     }
-    checkNotNull(ready)
     return futureValue
 }

--- a/chatkit-core/src/integrationTest/kotlin/mockitox/Mockito.kt
+++ b/chatkit-core/src/integrationTest/kotlin/mockitox/Mockito.kt
@@ -20,5 +20,3 @@ inline infix fun <reified T> T.returnsStub(f: T.() -> Unit) {
     given(this).willReturn(mock)
     f(mock)
 }
-
-

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorsStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorsStore.kt
@@ -38,6 +38,8 @@ class CursorsStore {
                         }
                     }
                 }
+            }.filterNot {
+                it is CursorSubscriptionEvent.NoEvent
             }
 }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorsStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorsStore.kt
@@ -1,5 +1,6 @@
 package com.pusher.chatkit.cursors
 
+
 class CursorsStore {
     private val map = mutableMapOf<String, UserCursorStore>()
 
@@ -16,6 +17,28 @@ class CursorsStore {
         }
     }
 
+    fun applyEvent(event: CursorSubscriptionEvent): List<CursorSubscriptionEvent> =
+            when (event) {
+                is CursorSubscriptionEvent.InitialState -> {
+                    event.cursors.map { cursor ->
+                        when (this[cursor.userId][cursor.roomId]) {
+                            cursor -> CursorSubscriptionEvent.NoEvent
+                            else -> CursorSubscriptionEvent.OnCursorSet(cursor)
+                        }
+                    }
+                }
+                else -> {
+                    listOf(event)
+                }
+            }.also { events ->
+                events.forEach { event ->
+                    when (event) {
+                        is CursorSubscriptionEvent.OnCursorSet -> {
+                            this[event.cursor.userId] += event.cursor
+                        }
+                    }
+                }
+            }
 }
 
 class UserCursorStore {
@@ -26,5 +49,4 @@ class UserCursorStore {
     }
 
     operator fun get(roomId: String) = cursors[roomId]
-
 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -1,5 +1,7 @@
 package com.pusher.chatkit.rooms
 
+import com.pusher.chatkit.memberships.MembershipSubscriptionEvent
+import com.pusher.chatkit.users.UserSubscriptionEvent
 import java.util.concurrent.ConcurrentHashMap
 
 internal class RoomStore(
@@ -30,4 +32,78 @@ internal class RoomStore(
     operator fun minusAssign(roomId: String) {
         roomsMap -= roomId
     }
+
+    fun applyUserSubscriptionEvent(
+            event: UserSubscriptionEvent
+    ): List<UserSubscriptionEvent> =
+        when (event) {
+            is UserSubscriptionEvent.InitialState -> {
+                val knownRooms = this.toList()
+                val removedFrom = knownRooms.filterNot {
+                    event.rooms.contains(it)
+                }.onEach {
+                    this -= it
+                }.map {
+                    UserSubscriptionEvent.RemovedFromRoomEvent(it.id)
+                }
+
+                val addedTo = event.rooms.filterNot {
+                    knownRooms.contains(it)
+                }.onEach {
+                    this += it
+                }.map {
+                    UserSubscriptionEvent.AddedToRoomEvent(it)
+                }
+
+                val updated = event.rooms.filter { nr ->
+                    knownRooms.any { kr ->
+                        kr == nr && !kr.deepEquals(nr)
+                    }
+                }.onEach {
+                    this += it
+                }.map {
+                    UserSubscriptionEvent.RoomUpdatedEvent(it)
+                }
+
+                listOf(event) + removedFrom + addedTo + updated
+            }
+            is UserSubscriptionEvent.AddedToRoomEvent ->
+                listOf(event.also { this += event.room })
+            is UserSubscriptionEvent.RoomUpdatedEvent ->
+                listOf(event.also { this += event.room })
+            is UserSubscriptionEvent.RoomDeletedEvent ->
+                listOf(event.also { this -= event.roomId })
+            is UserSubscriptionEvent.RemovedFromRoomEvent ->
+                listOf(event.also { this -= event.roomId })
+            is UserSubscriptionEvent.LeftRoomEvent ->
+                listOf(event.also { this[event.roomId]?.removeUser(event.userId) })
+            is UserSubscriptionEvent.JoinedRoomEvent ->
+                listOf(event.also { this[event.roomId]?.addUser(event.userId) })
+            else -> listOf(event)
+        }
+    
+    fun applyMembershipEvent(
+            roomId: String,
+            event: MembershipSubscriptionEvent
+    ): List<MembershipSubscriptionEvent> =
+            when (event) {
+                is MembershipSubscriptionEvent.InitialState -> {
+                    val existingMembers = this[roomId]?.memberUserIds.orEmpty()
+
+                    val joinedIds = event.userIds.filterNot { existingMembers.contains(it) }
+                    val leftIds = existingMembers.filterNot { event.userIds.contains(it) }
+
+                    joinedIds.map(MembershipSubscriptionEvent::UserJoined) +
+                            leftIds.map(MembershipSubscriptionEvent::UserLeft)
+                }
+                else ->
+                    listOf(event)
+            }.also { events ->
+                events.forEach { event ->
+                    when (event) {
+                        is MembershipSubscriptionEvent.UserJoined -> this[roomId]?.addUser(event.userId)
+                        is MembershipSubscriptionEvent.UserLeft -> this[roomId]?.removeUser(event.userId)
+                    }
+                }
+            }
 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionEvent.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionEvent.kt
@@ -16,4 +16,5 @@ sealed class RoomSubscriptionEvent {
     data class NewMessage(val message: Message) : RoomSubscriptionEvent()
     data class UserIsTyping(val userId: String) : RoomSubscriptionEvent()
     data class ErrorOccurred(val error: Error) : RoomSubscriptionEvent()
+    object NoEvent : RoomSubscriptionEvent()
 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionGroup.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomSubscriptionGroup.kt
@@ -4,13 +4,14 @@ import com.pusher.chatkit.ChatEvent
 import com.pusher.chatkit.ChatManagerEventConsumer
 import com.pusher.chatkit.PlatformClient
 import com.pusher.chatkit.cursors.CursorService
-import com.pusher.chatkit.cursors.CursorSubscriptionEvent
+import com.pusher.chatkit.cursors.CursorSubscriptionConsumer
+import com.pusher.chatkit.memberships.MembershipSubscriptionConsumer
 import com.pusher.chatkit.memberships.MembershipSubscriptionEvent
 import com.pusher.chatkit.memberships.MembershipSubscriptionEventParser
 import com.pusher.chatkit.subscription.ChatkitSubscription
 import com.pusher.chatkit.subscription.ResolvableSubscription
-import com.pusher.chatkit.users.User
 import com.pusher.chatkit.users.UserService
+import com.pusher.chatkit.users.User
 import com.pusher.platform.SubscriptionListeners
 import com.pusher.platform.logger.Logger
 import com.pusher.platform.network.Futures
@@ -20,28 +21,26 @@ import java.net.URLEncoder
 import java.util.concurrent.Future
 
 
-class RoomSubscriptionGroup(
+internal class RoomSubscriptionGroup(
         messageLimit: Int,
         roomId: String,
-        private val userService: UserService,
         cursorService: CursorService,
-        private val globalEventConsumers: MutableList<ChatManagerEventConsumer>,
+        cursorConsumer: ChatManagerEventConsumer,
+        membershipConsumer: MembershipSubscriptionConsumer,
+        roomConsumer: RoomSubscriptionConsumer,
         client: PlatformClient,
-        logger: Logger,
-        private val consumers: List<RoomConsumer>
+        logger: Logger
 ): ChatkitSubscription {
     init {
         check(messageLimit >= 0) { "messageLimit must be greater than or equal to 0" }
-
-        globalEventConsumers += this::consumeEvent
     }
 
     private val roomSubscription = ResolvableSubscription(
             client = client,
             path = "/rooms/${URLEncoder.encode(roomId, "UTF-8")}?&message_limit=$messageLimit",
             listeners = SubscriptionListeners(
-                    onEvent = { consumeEvent(it.body) },
-                    onError = { consumeEvent(RoomSubscriptionEvent.ErrorOccurred(it)) }
+                    onEvent = { roomConsumer(it.body) },
+                    onError = { roomConsumer(RoomSubscriptionEvent.ErrorOccurred(it)) }
             ),
             messageParser = RoomSubscriptionEventParser,
             description = "Room $roomId",
@@ -53,8 +52,8 @@ class RoomSubscriptionGroup(
             client = client,
             path = "/rooms/${URLEncoder.encode(roomId, "UTF-8")}/memberships",
             listeners = SubscriptionListeners(
-                    onEvent = { consumeEvent(it.body) },
-                    onError = { consumeEvent(MembershipSubscriptionEvent.ErrorOccurred(it)) }
+                    onEvent = { membershipConsumer(it.body) },
+                    onError = { membershipConsumer(MembershipSubscriptionEvent.ErrorOccurred(it)) }
             ),
             messageParser = MembershipSubscriptionEventParser,
             description = "Memberships room $roomId",
@@ -63,11 +62,8 @@ class RoomSubscriptionGroup(
 
     private val cursorsSubscription = cursorService.subscribeForRoom(
             roomId,
-            this::consumeEvent
+            consumer = cursorConsumer
     )
-
-    // Access synchronized on itself
-    private val typingTimers = HashMap<String, Future<Unit>>()
 
     override fun connect(): Subscription {
         roomSubscription.await()
@@ -81,116 +77,5 @@ class RoomSubscriptionGroup(
         roomSubscription.unsubscribe()
         membershipSubscription.unsubscribe()
         cursorsSubscription.unsubscribe()
-
-        globalEventConsumers -= this::consumeEvent
-    }
-
-    private fun forwardEvent(event: RoomEvent) {
-        if (event !is RoomEvent.NoEvent) {
-            consumers.forEach { consumer ->
-                consumer(event)
-            }
-        }
-    }
-
-    private fun consumeEvent(event: MembershipSubscriptionEvent) {
-        val events = when (event) {
-            is MembershipSubscriptionEvent.UserJoined -> listOf(
-                    userService.fetchUserBy(event.userId).map { user ->
-                        RoomEvent.UserJoined(user) as RoomEvent
-                    }.recover { RoomEvent.ErrorOccurred(it) }
-                )
-            is MembershipSubscriptionEvent.UserLeft -> listOf(
-                    userService.fetchUserBy(event.userId).map { user ->
-                        RoomEvent.UserLeft(user) as RoomEvent
-                    }.recover { RoomEvent.ErrorOccurred(it) }
-                )
-            is MembershipSubscriptionEvent.InitialState ->
-                userService.fetchUsersBy(event.userIds.toSet()).map { users ->
-                    users.values.map { user ->
-                        RoomEvent.UserJoined(user) as RoomEvent
-                    }
-                }.recover { listOf(RoomEvent.ErrorOccurred(it)) }
-            is MembershipSubscriptionEvent.ErrorOccurred ->
-                listOf(RoomEvent.ErrorOccurred(event.error))
-        }
-
-        events.forEach(::forwardEvent)
-    }
-
-    private fun consumeEvent(event: CursorSubscriptionEvent) {
-        forwardEvent(
-                when (event) {
-                    is CursorSubscriptionEvent.OnCursorSet -> RoomEvent.NewReadCursor(event.cursor)
-                    is CursorSubscriptionEvent.InitialState -> RoomEvent.InitialReadCursors(event.cursors)
-                    is CursorSubscriptionEvent.OnError -> RoomEvent.ErrorOccurred(event.error)
-                    is CursorSubscriptionEvent.NoEvent -> RoomEvent.NoEvent
-                }
-        )
-    }
-
-    private fun consumeEvent(event: RoomSubscriptionEvent) {
-        forwardEvent(
-                when (event) {
-                    is RoomSubscriptionEvent.UserIsTyping -> {
-                        userService.fetchUserBy(event.userId).map { user ->
-                            if (scheduleStopTypingEvent(user)) {
-                                RoomEvent.UserStartedTyping(user)
-                            } else {
-                                RoomEvent.NoEvent
-                            }
-                        }.recover {
-                            RoomEvent.ErrorOccurred(it)
-                        }
-                    }
-                    is RoomSubscriptionEvent.NewMessage ->
-                        userService.fetchUserBy(event.message.userId).map { user ->
-                            event.message.user = user
-                            RoomEvent.Message(event.message) as RoomEvent
-                        }.recover {
-                            RoomEvent.ErrorOccurred(it)
-                        }
-                    is RoomSubscriptionEvent.ErrorOccurred ->
-                        RoomEvent.ErrorOccurred(event.error)
-                }
-        )
-    }
-
-    private fun consumeEvent(event: ChatEvent) {
-        forwardEvent(
-                // This function must map events which we wish to report at room scope that
-                // are not received at room scope from the backend.
-                // Be careful, if you map an event where which originated here, you will create
-                // an infinite loop consuming that event.
-                when (event) {
-                    is ChatEvent.RoomUpdated ->
-                        RoomEvent.RoomUpdated(event.room)
-                    is ChatEvent.RoomDeleted ->
-                        RoomEvent.RoomDeleted(event.roomId)
-                    is ChatEvent.PresenceChange ->
-                        RoomEvent.PresenceChange(event.user, event.currentState, event.prevState)
-                    else ->
-                        RoomEvent.NoEvent
-                }
-        )
-    }
-
-    private fun scheduleStopTypingEvent(user: User): Boolean {
-        synchronized(typingTimers) {
-            val new = typingTimers[user.id] == null
-            if (!new) {
-                typingTimers[user.id]!!.cancel()
-            }
-
-            typingTimers[user.id] = Futures.schedule {
-                Thread.sleep(1_500)
-                synchronized(typingTimers) {
-                    typingTimers.remove(user.id)
-                }
-                forwardEvent(RoomEvent.UserStoppedTyping(user))
-            }
-
-            return new
-        }
     }
 }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/CursorStoreSpec.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/CursorStoreSpec.kt
@@ -1,0 +1,73 @@
+package com.pusher.chatkit
+
+import com.google.common.truth.Truth.assertThat
+import com.pusher.chatkit.cursors.Cursor
+import com.pusher.chatkit.cursors.CursorSubscriptionEvent
+import com.pusher.chatkit.cursors.CursorsStore
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+class CursorStoreSpec : Spek({
+    describe("cursor store") {
+        describe("on receiving new InitialState event from room subscription") {
+            val subject = CursorsStore()
+
+            subject += listOf(
+                    Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"),
+                    Cursor("mike", "1", 2, "2017-11-29T16:59:58Z")
+            )
+
+            val events = subject.applyEvent(CursorSubscriptionEvent.InitialState(
+                    listOf(
+                            Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"),
+                            Cursor("mike", "1", 3, "2017-11-29T16:59:59Z"),
+                            Cursor("viv", "1", 3, "2017-11-29T16:59:59Z")
+                    )
+            ))
+
+            it("should emit events describing the difference in state") {
+                assertThat(events).containsExactly(
+                        CursorSubscriptionEvent.OnCursorSet(Cursor("mike", "1", 3, "2017-11-29T16:59:59Z")),
+                        CursorSubscriptionEvent.OnCursorSet(Cursor("viv", "1", 3, "2017-11-29T16:59:59Z"))
+                )
+            }
+
+            it("should update the contents of the store") {
+                assertThat(subject["callum"]["1"]).isEqualTo(Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"))
+                assertThat(subject["mike"]["1"]).isEqualTo(Cursor("mike", "1", 3, "2017-11-29T16:59:59Z"))
+                assertThat(subject["viv"]["1"]).isEqualTo(Cursor("viv", "1", 3, "2017-11-29T16:59:59Z"))
+            }
+        }
+
+        describe("on receiving new InitialState event from user subscription") {
+            val subject = CursorsStore()
+
+            subject += listOf(
+                    Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"),
+                    Cursor("callum", "2", 2, "2017-11-29T16:59:58Z")
+            )
+
+            val events = subject.applyEvent(CursorSubscriptionEvent.InitialState(
+                    listOf(
+                            Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"),
+                            Cursor("callum", "2", 3, "2017-11-29T16:59:59Z"),
+                            Cursor("callum", "3", 4, "2017-11-29T16:59:59Z")
+                    )
+            ))
+
+            it("should emit events describing the difference in state") {
+                assertThat(events).containsExactly(
+                        CursorSubscriptionEvent.OnCursorSet(Cursor("callum", "2", 3, "2017-11-29T16:59:59Z")),
+                        CursorSubscriptionEvent.OnCursorSet(Cursor("callum", "3", 4, "2017-11-29T16:59:59Z"))
+                )
+            }
+
+            it("should update the contents of the store") {
+                assertThat(subject["callum"]["1"]).isEqualTo(Cursor("callum", "1", 1, "2017-11-29T16:59:58Z"))
+                assertThat(subject["callum"]["2"]).isEqualTo(Cursor("callum", "2", 3, "2017-11-29T16:59:59Z"))
+                assertThat(subject["callum"]["3"]).isEqualTo(Cursor("callum", "3", 4, "2017-11-29T16:59:59Z"))
+            }
+        }
+    }
+})

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/RoomStoreSpek.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/RoomStoreSpek.kt
@@ -1,0 +1,104 @@
+package com.pusher.chatkit
+
+import com.google.common.truth.Truth.assertThat
+import com.pusher.chatkit.memberships.MembershipSubscriptionEvent
+import com.pusher.chatkit.rooms.Room
+import com.pusher.chatkit.rooms.RoomStore
+import com.pusher.chatkit.users.User
+import com.pusher.chatkit.users.UserSubscriptionEvent
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+class RoomStoreSpek : Spek({
+    describe("RoomStore") {
+        describe("on receiving new InitialState User event") {
+            val subject = RoomStore()
+
+            subject += listOf(
+                    Room("1", "ham", "one", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("2", "ham", "two", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("3", "ham", "three", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("4", "ham", "four", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("5", "ham", "five", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("7", "ham", "seven", false, mapOf("pre" to "set", "custom" to "data"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("8", "ham", "eight", false, mapOf("pre" to "set"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                    Room("9", "ham", "nine", false, mapOf("pre" to "set"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")
+            )
+
+            val replacementState = UserSubscriptionEvent.InitialState(
+                    rooms = listOf(
+                            Room("1", "ham", "one", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("3", "ham", "three", true, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("4", "ham", "four", false, mapOf("set" to "now"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("5", "ham", "5ive", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("6", "ham", "size", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("7", "ham", "seven", false, mapOf("pre" to "set", "custom" to "data", "third" to "field"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("8", "ham", "eight", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                            Room("9", "ham", "9ine", true, mapOf("pre" to "set", "and" to "updated"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")
+                    ),
+                    currentUser = User("viv", "2017-04-13T14:10:04Z", "2017-04-13T14:10:04Z", "Vivan", null, mapOf("email" to "vivan@pusher.com"))
+            )
+
+            val events = subject.applyUserSubscriptionEvent(replacementState)
+
+            it("should emit expected hooks") {
+                assertThat(events).containsExactly(
+                        UserSubscriptionEvent.RemovedFromRoomEvent("2"),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("3", "ham", "three", true, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("4", "ham", "four", false, mapOf("set" to "now"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("5", "ham", "5ive", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.AddedToRoomEvent(Room("6", "ham", "size", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("7", "ham", "seven", false, mapOf("pre" to "set", "custom" to "data", "third" to "field"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("8", "ham", "eight", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        UserSubscriptionEvent.RoomUpdatedEvent(Room("9", "ham", "9ine", true, mapOf("pre" to "set", "and" to "updated"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")),
+                        replacementState // this event is not removed during the expansion because the roomStore has not dealt with the currentUser field
+                )
+            }
+
+            it("should update the room store") {
+                val roomStoreContents = subject.toList().sortedBy { it.id }
+
+                assertThat(roomStoreContents).hasSize(8)
+
+                val differences = roomStoreContents.zip(listOf(
+                        Room("1", "ham", "one", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("3", "ham", "three", true, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("4", "ham", "four", false, mapOf("set" to "now"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("5", "ham", "5ive", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("6", "ham", "size", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("7", "ham", "seven", false, mapOf("pre" to "set", "custom" to "data", "third" to "field"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("8", "ham", "eight", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", ""),
+                        Room("9", "ham", "9ine", true, mapOf("pre" to "set", "and" to "updated"), "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")
+                )).filterNot { (l, r) -> l.deepEquals(r) }
+
+                assertThat(differences).isEmpty()
+            }
+        }
+
+        describe("On receiving new InitialState Membership event") {
+            val subject = RoomStore()
+
+            val room =  Room("1", "ham", "one", false, null, "2017-04-13T14:10:38Z", "2017-04-13T14:10:38Z", "")
+            setOf("callum", "mike", "alice").forEach { room.addUser(it) }
+
+            subject += room
+
+            val events = subject.applyMembershipEvent(
+                    room.id,
+                    MembershipSubscriptionEvent.InitialState(listOf("mike", "callum", "bob"))
+            )
+
+            it("should emit the correct events") {
+                assertThat(events).containsExactly(
+                        MembershipSubscriptionEvent.UserJoined("bob"),
+                        MembershipSubscriptionEvent.UserLeft("alice")
+                )
+            }
+
+            it("should update the room membership") {
+                assertThat(room.memberUserIds).containsExactly("mike", "callum", "bob")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Improve and test the reconcilliation of new state snapshots received when a subscription is reconnected during a session.

Part of improving the clarity and testability involed moving the responsibility for applying state changes (and rewriting the event stream to reflect them, in the case of new state snapshots) down to the individual state stores.