### PR TITLE
Fix expiration check

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/messages/multipart/Message.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/messages/multipart/Message.kt
@@ -62,7 +62,7 @@ sealed class Payload {
             internal var expiration: Date
     ) : Payload() {
         fun url(): Result<String, Error> =
-                if (Date().time - expiration.time > 30 * 60 * 1000) {
+                if (expiration.time - Date().time > 30 * 60 * 1000) {
                     downloadUrl.asSuccess()
                 } else {
                     refresher.refresh(this)


### PR DESCRIPTION
Expiration time is the greater of the two (in the future) so the current time should be subtracted when comparing with greater than.

The tests still fail because the refresh endpoint is currently disabled.