### PR TITLE
Added Missing subscribeToRoomMultipart

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
@@ -152,6 +152,40 @@ class CurrentUser(
     ) = makeCallback({ syncCurrentUser.subscribeToRoom(roomId, messageLimit, consumer) }, callback)
 
     @JvmOverloads
+    fun subscribeToRoomMultipart(
+            room: Room,
+            listeners: RoomListeners,
+            messageLimit: Int = 10,
+            callback: (Subscription) -> Unit
+    ) = makeCallback({ syncCurrentUser.subscribeToRoomMultipart(room, listeners, messageLimit) }, callback)
+
+    @JvmOverloads
+    fun subscribeToRoomMultipart(
+            roomId: String,
+            listeners: RoomListeners,
+            messageLimit: Int = 10,
+            callback: (Subscription) -> Unit
+    ) = makeCallback({ syncCurrentUser.subscribeToRoomMultipart(roomId, listeners, messageLimit) }, callback)
+
+    @JvmOverloads
+    @Deprecated("use subscribeToRoomMultipart")
+    fun subscribeToRoomMultipart(
+            room: Room,
+            messageLimit: Int = 10,
+            consumer: RoomConsumer,
+            callback: (Subscription) -> Unit
+    ) = makeCallback({ syncCurrentUser.subscribeToRoomMultipart(room, messageLimit, consumer) }, callback)
+
+    @JvmOverloads
+    @Deprecated("use subscribeToRoomMultipart")
+    fun subscribeToRoomMultipart(
+            roomId: String,
+            messageLimit: Int = 10,
+            consumer: RoomConsumer,
+            callback: (Subscription) -> Unit
+    ) = makeCallback({ syncCurrentUser.subscribeToRoomMultipart(roomId, messageLimit, consumer) }, callback)
+    
+    @JvmOverloads
     @Deprecated("use fetchMultipartMessages")
     fun fetchMessages(
             roomId: String,


### PR DESCRIPTION
Problem: in version 1.2.0 subscribeToRoom functions CurrentUser.kt are deprecated and instructed to use subscribeToRoomMultipart functions but these functions are missing.

Solution: Added subscribeToRoomMultipart functions to CurrentUser.kt with neccessary implementations.