### PR TITLE
Match token provider interfaces more closely

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/pushnotifications/BeamsTokenProviderService.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/pushnotifications/BeamsTokenProviderService.kt
@@ -3,7 +3,8 @@ package com.pusher.chatkit.pushnotifications
 import com.pusher.chatkit.PlatformClient
 import com.pusher.chatkit.util.parseAs
 import com.pusher.platform.RequestOptions
-import com.pusher.util.Result
+import com.pusher.util.orElse
+import elements.Errors
 import java.net.URLEncoder
 
 data class BeamsTokenProviderResponse(val token: String?)
@@ -11,13 +12,18 @@ data class BeamsTokenProviderResponse(val token: String?)
 class BeamsTokenProviderService(
         private val beamsTokenProviderClient: PlatformClient
 ) {
-    fun fetchToken(userId: String): Result<BeamsTokenProviderResponse, elements.Error> {
-        return beamsTokenProviderClient.doRequest(
-                options = RequestOptions(
-                        path = "/beams-tokens?user_id=${URLEncoder.encode(userId, "UTF-8")}",
-                        method = "GET"
-                ),
-                responseParser = { it.parseAs<BeamsTokenProviderResponse>() }
-        )
-    }
+    fun fetchToken(userId: String): String =
+            beamsTokenProviderClient.doRequest(
+                    options = RequestOptions(
+                            path = "/beams-tokens?user_id=${URLEncoder.encode(userId, "UTF-8")}",
+                            method = "GET"
+                    ),
+                    responseParser = { it.parseAs<BeamsTokenProviderResponse>() }
+            ).mapFailure {
+                Errors.other("Could not authenticate with push notifications service: $it")
+            }.flatMap { response ->
+                response.token.orElse {
+                    Errors.other("Could not get auth token for push notification service")
+                }
+            }.successOrThrow()
 }


### PR DESCRIPTION
We can't actually implement the beams token provider interface in the
BeamsTokenProviderService, because it has to be referenced from the core
project, however, we can make it easier to use by matching the interface
more closely