### PR TITLE
Check if the pusher_platform_local property is set when attempting to publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 jdk: oraclejdk8
 
 # safelist

--- a/build.gradle
+++ b/build.gradle
@@ -41,14 +41,22 @@ allprojects {
         jcenter()
         mavenCentral()
     }
-    if (tasks.findByName('bintrayUpload')) {
-        task verifyBintrayCredentials {
+
+    task verifyBintrayCredentials {
+        doFirst {
             def out = []
             if (bintray_user == null) out += "Missing `bintrayUser` property or BINTRAY_USER env var"
             if (bintray_api_key == null) out += "Missing `bintrayApiKey` property or BINTRAY_API_KEY env var"
             if (!out.isEmpty()) throw new IllegalStateException("\n" + out.join("\n"))
         }
-        bintrayUpload.doFirst verifyBintrayCredentials
+    }
+
+    task checkIfPusherPlatformLocalIsSet {
+        doFirst {
+            if (rootProject.properties.containsKey('pusher_platform_local')) {
+                throw new Exception("Please unset `pusher_platform_local` in the global gradle.properties file")
+            }
+        }
     }
 }
 

--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -94,6 +94,8 @@ bintray {
     }
 }
 
+bintrayUpload.dependsOn(['checkIfPusherPlatformLocalIsSet', 'verifyBintrayCredentials'])
+
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'

--- a/chatkit-core/build.gradle
+++ b/chatkit-core/build.gradle
@@ -83,6 +83,8 @@ bintray {
     }
 }
 
+bintrayUpload.dependsOn(['checkIfPusherPlatformLocalIsSet', 'verifyBintrayCredentials'])
+
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource


### PR DESCRIPTION
If this is set, we brick our newly published version and since the global gradle properties files is not checked into the repository, it does not show up in the git diff and is very easily skipped.