### PR TITLE
Fix update room losing current member ids

### DIFF
--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -179,27 +179,44 @@ class RoomSpek : Spek({
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
 
+
             val badEvents = ConcurrentLinkedQueue<RoomEvent>()
+            var countEvents = 0
             alice.subscribeToRoom(alice.generalRoom) { event ->
                 when (event) {
                     is RoomEvent.UserJoined ->
-                        if (!alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
-                            badEvents.add(event)
-                        }
+                        if (event.user.id.contains("pusherino")){
+                            countEvents++
+                                if (!alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
+                                badEvents.add(event)
+                        }}
                     is RoomEvent.UserLeft ->
+                        if (event.user.id.contains("pusherino")){
+                            countEvents++
                         if (alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
                             badEvents.add(event)
-                        }
+                        }}
                 }
             }
 
-            pusherino.removeUsersFromRoom(pusherino.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
-            pusherino.addUsersToRoom(pusherino.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
-            pusherino.removeUsersFromRoom(pusherino.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
-            pusherino.addUsersToRoom(pusherino.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
+            alice.removeUsersFromRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
+            alice.addUsersToRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
+            alice.removeUsersFromRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
+            alice.addUsersToRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
 
 
-            assertThat(badEvents).isEmpty()
+            if (countEvents >= 4) {
+                assertThat(badEvents).isEmpty()
+            }
+            else
+            {
+                assertThat(countEvents >= 4)
+            }
+
+
+
+
+
         }
 
 

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -189,7 +189,7 @@ class RoomSpek : Spek({
             }
 
             assertThat(superUser.generalRoom.memberUserIds.size).isEqualTo(2) //alice and super user
-            superUser.updateRoom(superUser.generalRoom, customData = mapOf("key" to "data") ).assumeSuccess()
+            superUser.updateRoom(superUser.generalRoom, customData = mapOf("key" to "data")).assumeSuccess()
             roomUpdated.await()
             assertThat(superUser.generalRoom.memberUserIds.size).isEqualTo(2)
 
@@ -214,7 +214,7 @@ class RoomSpek : Spek({
             }
 
             assertThat(superUser.generalRoom.memberUserIds.size).isEqualTo(2) //alice and super user
-            superUser.sendSimpleMessage(superUser.generalRoom, "hello" ).assumeSuccess()
+            superUser.sendSimpleMessage(superUser.generalRoom, "hello").assumeSuccess()
             roomUpdated.await()
             assertThat(superUser.generalRoom.memberUserIds.size).isEqualTo(2)
         }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -199,13 +199,10 @@ class RoomSpek : Spek({
 
             setUpInstanceWith(createDefaultRole(), newUsers(PUSHERINO, ALICE), newRoom(GENERAL, ALICE))
             val superUser = chatFor(SUPER_USER).connect().assumeSuccess()
-            val roomUpdated = CountDownLatch(2)
+            val roomUpdated = CountDownLatch(1)
 
             superUser.subscribeToRoomMultipart(superUser.generalRoom) { event ->
                 when (event) {
-                    is RoomEvent.MultipartMessage -> {
-                        roomUpdated.countDown()
-                    }
                     is RoomEvent.RoomUpdated -> {
                         assertThat(event.room.memberUserIds.size).isEqualTo(2)
                         roomUpdated.countDown()

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -182,8 +182,8 @@ class RoomSpek : Spek({
             superUser.subscribeToRoomMultipart(superUser.generalRoom) { event ->
                 when (event) {
                     is RoomEvent.RoomUpdated -> {
-                        roomUpdated.countDown()
                         assertThat(event.room.memberUserIds.size).isEqualTo(2)
+                        roomUpdated.countDown()
                     }
                 }
             }
@@ -207,8 +207,8 @@ class RoomSpek : Spek({
                         roomUpdated.countDown()
                     }
                     is RoomEvent.RoomUpdated -> {
-                        roomUpdated.countDown()
                         assertThat(event.room.memberUserIds.size).isEqualTo(2)
+                        roomUpdated.countDown()
                     }
                 }
             }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -183,6 +183,7 @@ class RoomSpek : Spek({
                 when (event) {
                     is RoomEvent.RoomUpdated -> {
                         roomUpdated.countDown()
+                        assertThat(event.room.memberUserIds.size).isEqualTo(2)
                     }
                 }
             }
@@ -207,6 +208,7 @@ class RoomSpek : Spek({
                     }
                     is RoomEvent.RoomUpdated -> {
                         roomUpdated.countDown()
+                        assertThat(event.room.memberUserIds.size).isEqualTo(2)
                     }
                 }
             }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -179,23 +179,24 @@ class RoomSpek : Spek({
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
 
-
             val badEvents = ConcurrentLinkedQueue<RoomEvent>()
             var countEvents = 0
             alice.subscribeToRoom(alice.generalRoom) { event ->
                 when (event) {
                     is RoomEvent.UserJoined ->
-                        if (event.user.id.contains("pusherino")){
+                        if (event.user.id.contains("pusherino")) {
                             countEvents++
-                                if (!alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
+                            if (!alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
                                 badEvents.add(event)
-                        }}
+                            }
+                        }
                     is RoomEvent.UserLeft ->
-                        if (event.user.id.contains("pusherino")){
+                        if (event.user.id.contains("pusherino")) {
                             countEvents++
-                        if (alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
-                            badEvents.add(event)
-                        }}
+                            if (alice.generalRoom.memberUserIds.contains("PUSHERINO")) {
+                                badEvents.add(event)
+                            }
+                        }
                 }
             }
 
@@ -204,22 +205,12 @@ class RoomSpek : Spek({
             alice.removeUsersFromRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
             alice.addUsersToRoom(alice.generalRoom.id, listOf(PUSHERINO)).assumeSuccess()
 
-
             if (countEvents >= 4) {
                 assertThat(badEvents).isEmpty()
-            }
-            else
-            {
+            } else {
                 assertThat(countEvents >= 4)
             }
-
-
-
-
-
         }
-
-
     }
 
     describe("currentUser '$PUSHERINO'") {

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -2,18 +2,30 @@ package com.pusher.chatkit
 
 import com.google.common.truth.Truth.assertThat
 import com.pusher.chatkit.Rooms.GENERAL
+import com.pusher.chatkit.Rooms.NOT_GENERAL
+import com.pusher.chatkit.Rooms.SAMPLE_CUSTOM_DATA
 import com.pusher.chatkit.Users.ALICE
 import com.pusher.chatkit.Users.PUSHERINO
 import com.pusher.chatkit.Users.SUPER_USER
+import com.pusher.chatkit.rooms.Room
 import com.pusher.chatkit.rooms.RoomEvent
+import com.pusher.chatkit.test.InstanceActions.changeRoomName
 import com.pusher.chatkit.test.InstanceActions.createDefaultRole
+import com.pusher.chatkit.test.InstanceActions.deleteRoom
 import com.pusher.chatkit.test.InstanceActions.newRoom
 import com.pusher.chatkit.test.InstanceActions.newUsers
 import com.pusher.chatkit.test.InstanceSupervisor.setUpInstanceWith
 import com.pusher.chatkit.test.InstanceSupervisor.tearDownInstance
+import com.pusher.chatkit.test.run
+import com.pusher.chatkit.users.User
+import com.pusher.chatkit.util.FutureValue
+import com.pusher.util.Result
+import com.pusher.util.Result.Failure
+import com.pusher.util.Result.Success
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 
 class RoomSpek : Spek({

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -198,11 +198,14 @@ class RoomSpek : Spek({
 
             setUpInstanceWith(createDefaultRole(), newUsers(PUSHERINO, ALICE), newRoom(GENERAL, ALICE))
             val superUser = chatFor(SUPER_USER).connect().assumeSuccess()
-            val roomUpdated = CountDownLatch(1)
+            val roomUpdated = CountDownLatch(2)
 
             superUser.subscribeToRoomMultipart(superUser.generalRoom) { event ->
                 when (event) {
                     is RoomEvent.MultipartMessage -> {
+                        roomUpdated.countDown()
+                    }
+                    is RoomEvent.RoomUpdated -> {
                         roomUpdated.countDown()
                     }
                 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
@@ -183,8 +183,10 @@ class SynchronousChatManager constructor(
 
     private fun transformUserSubscriptionEvent(event: UserSubscriptionEvent): ChatEvent =
             when (event) {
-                is UserSubscriptionEvent.AddedToRoomEvent ->
+                is UserSubscriptionEvent.AddedToRoomEvent -> {
+                    event.room.addUser(currentUser.id)
                     ChatEvent.AddedToRoom(event.room)
+                }
                 is UserSubscriptionEvent.RemovedFromRoomEvent ->
                     ChatEvent.RemovedFromRoom(event.roomId)
                 is UserSubscriptionEvent.RoomUpdatedEvent ->

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
@@ -32,6 +32,10 @@ data class Room(
         memberUserIds() += userId
     }
 
+    fun addAllUsers(userIds: Set<String>) {
+        memberUserIds().addAll(userIds)
+    }
+
     override fun equals(other: Any?) = (other is Room) && other.id == this.id
 
     override fun hashCode(): Int { return id.hashCode() }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
@@ -24,15 +24,15 @@ data class Room(
     private fun memberUserIds(): MutableSet<String> = _memberUserIds
             ?: mutableSetOf<String>().also { _memberUserIds = it }
 
-    fun removeUser(userId: String) {
+    internal fun removeUser(userId: String) {
         memberUserIds() -= userId
     }
 
-    fun addUser(userId: String) {
+    internal fun addUser(userId: String) {
         memberUserIds() += userId
     }
 
-    fun addAllUsers(userIds: Set<String>) {
+    internal fun addAllUsers(userIds: Set<String>) {
         memberUserIds().addAll(userIds)
     }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -60,6 +60,7 @@ internal class RoomStore(
                     val addedTo = event.rooms.filterNot {
                         knownRooms.contains(it)
                     }.onEach {
+                        it.addAllUsers(roomsMap[it.id]?.memberUserIds.orEmpty())
                         this += it
                     }.map {
                         UserSubscriptionEvent.AddedToRoomEvent(it)
@@ -70,6 +71,7 @@ internal class RoomStore(
                             kr == nr && !kr.deepEquals(nr)
                         }
                     }.onEach {
+                        it.addAllUsers(roomsMap[it.id]?.memberUserIds.orEmpty())
                         this += it
                     }.map {
                         UserSubscriptionEvent.RoomUpdatedEvent(it)
@@ -78,7 +80,10 @@ internal class RoomStore(
                     listOf(event) + removedFrom + addedTo + updated
                 }
                 is UserSubscriptionEvent.AddedToRoomEvent ->
-                    listOf(event.also { this += event.room })
+                    listOf(event.also {
+                        event.room.addAllUsers(roomsMap[event.room.id]?.memberUserIds.orEmpty())
+                        this += event.room
+                    })
                 is UserSubscriptionEvent.RoomUpdatedEvent ->
                     listOf(event.also {
                         //memberUserIDs are not populated in Rooms we have just deserialised from the

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -61,6 +61,7 @@ internal class RoomStore(
                         knownRooms.contains(it)
                     }.onEach {
                         it.addAllUsers(roomsMap[it.id]?.memberUserIds.orEmpty())
+                        it.addUser(event.currentUser.id)
                         this += it
                     }.map {
                         UserSubscriptionEvent.AddedToRoomEvent(it)

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -81,7 +81,7 @@ internal class RoomStore(
                     listOf(event.also { this += event.room })
                 is UserSubscriptionEvent.RoomUpdatedEvent ->
                     listOf(event.also {
-                        //member user ids seem to get lost here, so append whatever we had saved last time
+                        //memberUserIds are null in this case, so append whatever we had saved last time
                         event.room.addAllUsers(roomsMap[event.room.id]?.memberUserIds.orEmpty())
                         this += event.room})
                 is UserSubscriptionEvent.RoomDeletedEvent ->

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -60,8 +60,6 @@ internal class RoomStore(
                     val addedTo = event.rooms.filterNot {
                         knownRooms.contains(it)
                     }.onEach {
-                        it.addAllUsers(roomsMap[it.id]?.memberUserIds.orEmpty())
-                        it.addUser(event.currentUser.id)
                         this += it
                     }.map {
                         UserSubscriptionEvent.AddedToRoomEvent(it)

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -81,7 +81,10 @@ internal class RoomStore(
                     listOf(event.also { this += event.room })
                 is UserSubscriptionEvent.RoomUpdatedEvent ->
                     listOf(event.also {
-                        //memberUserIds are null in this case, so append whatever we had saved last time
+                        //memberUserIDs are not populated in Rooms we have just deserialised from the
+                        // server because we receive them separately via membership subscriptions,
+                        // so we must copy the set we have been tracking on our previous instance
+                        // of the Room on to this new instance
                         event.room.addAllUsers(roomsMap[event.room.id]?.memberUserIds.orEmpty())
                         this += event.room})
                 is UserSubscriptionEvent.RoomDeletedEvent ->

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -80,7 +80,6 @@ internal class RoomStore(
                 }
                 is UserSubscriptionEvent.AddedToRoomEvent ->
                     listOf(event.also {
-                        event.room.addAllUsers(roomsMap[event.room.id]?.memberUserIds.orEmpty())
                         this += event.room
                     })
                 is UserSubscriptionEvent.RoomUpdatedEvent ->

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomStore.kt
@@ -80,7 +80,10 @@ internal class RoomStore(
                 is UserSubscriptionEvent.AddedToRoomEvent ->
                     listOf(event.also { this += event.room })
                 is UserSubscriptionEvent.RoomUpdatedEvent ->
-                    listOf(event.also { this += event.room })
+                    listOf(event.also {
+                        //member user ids seem to get lost here, so append whatever we had saved last time
+                        event.room.addAllUsers(roomsMap[event.room.id]?.memberUserIds.orEmpty())
+                        this += event.room})
                 is UserSubscriptionEvent.RoomDeletedEvent ->
                     listOf(event.also { this -= event.roomId })
                 is UserSubscriptionEvent.RemovedFromRoomEvent ->


### PR DESCRIPTION
Previously whenever the room was updated (room name changed / room data changed / message sent) the returned room would lose all the member ids subscribed. 

We have written two tests to prove this:
* updating room with custom data
* sending a message to a room

I have had to add a new method on to the Room.kt to support adding many users, but this didn't appear to have any knock on effects as the member id list was only used locally (didn't call the server).