### PR TITLE
Add support for Push Notification Title Override in Rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-android/compare/v1.6.0...HEAD)
 
+### Added
+
+- Support for `PushNotificationTitleOverride` field in the Room model
+
 ## [1.6.0](https://github.com/pusher/chatkit-android/compare/v1.5.0...v1.6.0) - 2019-07-16
 
 No changes in this version. Previous versions from 1.4.0 onwards were released incorrectly

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -9,6 +9,7 @@ import com.pusher.chatkit.Users.PUSHERINO
 import com.pusher.chatkit.Users.SUPER_USER
 import com.pusher.chatkit.rooms.Room
 import com.pusher.chatkit.rooms.RoomEvent
+import com.pusher.chatkit.rooms.RoomPushNotificationTitle
 import com.pusher.chatkit.test.InstanceActions.changeRoomName
 import com.pusher.chatkit.test.InstanceActions.createDefaultRole
 import com.pusher.chatkit.test.InstanceActions.deleteRoom
@@ -412,7 +413,7 @@ class RoomSpek : Spek({
                 }
             }
 
-            val pnTitleOverride = "my app name"
+            val pnTitleOverride = RoomPushNotificationTitle.Override("my app name")
 
             superUser.updateRoom(
                 room = superUser.generalRoom,
@@ -421,7 +422,7 @@ class RoomSpek : Spek({
 
             assertThat(updatedRoom.name).isEqualTo(GENERAL)
             assertThat(updatedRoom.isPrivate).isEqualTo(false)
-            assertThat(updatedRoom.pushNotificationTitleOverride).isEqualTo(pnTitleOverride)
+            assertThat(updatedRoom.pushNotificationTitleOverride).isEqualTo(pnTitleOverride.title)
         }
 
         it("updates to remove pn title override") {
@@ -446,7 +447,7 @@ class RoomSpek : Spek({
 
             superUser.updateRoom(
                 room = superUser.generalRoom,
-                pushNotificationTitleOverride = null
+                pushNotificationTitleOverride = RoomPushNotificationTitle.NoOverride
             ).assumeSuccess()
 
             assertThat(updatedRoom.name).isEqualTo(GENERAL)

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/test/InstanceSupervisor.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/test/InstanceSupervisor.kt
@@ -301,13 +301,14 @@ object InstanceActions {
         )
     }.withName("Create new users: ${names.joinToString(", ")}")
 
-    fun newRoom(name: String, vararg userNames: String, isPrivate: Boolean = false, customData: CustomData? = null) = {
+    fun newRoom(name: String, vararg userNames: String, pushNotificationTitleOverride: String? = null, isPrivate: Boolean = false, customData: CustomData? = null) = {
         chatkitInstance.request<JsonElement>(
                 options = RequestOptions(
                         path = "/rooms",
                         method = "POST",
                         body = mutableMapOf<String, Any?>(
                                 "name" to name,
+                                "push_notification_title_override" to pushNotificationTitleOverride,
                                 "user_ids" to userNames,
                                 "private" to isPrivate
                         ).apply {

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
@@ -9,6 +9,7 @@ import com.pusher.chatkit.messages.multipart.NewPart
 import com.pusher.chatkit.rooms.Room
 import com.pusher.chatkit.rooms.RoomConsumer
 import com.pusher.chatkit.rooms.RoomListeners
+import com.pusher.chatkit.rooms.RoomPushNotificationTitle
 import com.pusher.chatkit.users.User
 import com.pusher.platform.network.Futures
 import com.pusher.util.Result
@@ -92,15 +93,7 @@ class CurrentUser(
     fun updateRoom(
             room: Room,
             name: String,
-            isPrivate: Boolean? = null,
-            customData: CustomData? = null,
-            callback: (Result<Unit, Error>) -> Unit
-    ) = makeCallback({ syncCurrentUser.updateRoom(room, name, isPrivate, customData) }, callback)
-
-    fun updateRoom(
-            room: Room,
-            name: String,
-            pushNotificationTitleOverride: String,
+            pushNotificationTitleOverride: RoomPushNotificationTitle? = null,
             isPrivate: Boolean? = null,
             customData: CustomData? = null,
             callback: (Result<Unit, Error>) -> Unit
@@ -109,14 +102,7 @@ class CurrentUser(
     @JvmOverloads
     fun updateRoom(roomId: String,
                    name: String,
-                   isPrivate: Boolean? = null,
-                   customData: CustomData? = null,
-                   callback: (Result<Unit, Error>) -> Unit
-    ) = makeCallback({ syncCurrentUser.updateRoom(roomId, name, isPrivate, customData) }, callback)
-
-    fun updateRoom(roomId: String,
-                   name: String,
-                   pushNotificationTitleOverride: String,
+                   pushNotificationTitleOverride: RoomPushNotificationTitle? = null,
                    isPrivate: Boolean? = null,
                    customData: CustomData? = null,
                    callback: (Result<Unit, Error>) -> Unit

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/CurrentUser.kt
@@ -81,11 +81,12 @@ class CurrentUser(
     fun createRoom(
             id: String? = null,
             name: String,
+            pushNotificationTitleOverride: String? = null,
             isPrivate: Boolean = false,
             customData: CustomData? = null,
             userIds: List<String> = emptyList(),
             callback: (Result<Room, Error>) -> Unit
-    ) = makeCallback({ syncCurrentUser.createRoom(id, name, isPrivate, customData, userIds) }, callback)
+    ) = makeCallback({ syncCurrentUser.createRoom(id, name, pushNotificationTitleOverride, isPrivate, customData, userIds) }, callback)
 
     @JvmOverloads
     fun updateRoom(
@@ -96,6 +97,15 @@ class CurrentUser(
             callback: (Result<Unit, Error>) -> Unit
     ) = makeCallback({ syncCurrentUser.updateRoom(room, name, isPrivate, customData) }, callback)
 
+    fun updateRoom(
+            room: Room,
+            name: String,
+            pushNotificationTitleOverride: String,
+            isPrivate: Boolean? = null,
+            customData: CustomData? = null,
+            callback: (Result<Unit, Error>) -> Unit
+    ) = makeCallback({ syncCurrentUser.updateRoom(room, name, pushNotificationTitleOverride, isPrivate, customData) }, callback)
+
     @JvmOverloads
     fun updateRoom(roomId: String,
                    name: String,
@@ -103,6 +113,14 @@ class CurrentUser(
                    customData: CustomData? = null,
                    callback: (Result<Unit, Error>) -> Unit
     ) = makeCallback({ syncCurrentUser.updateRoom(roomId, name, isPrivate, customData) }, callback)
+
+    fun updateRoom(roomId: String,
+                   name: String,
+                   pushNotificationTitleOverride: String,
+                   isPrivate: Boolean? = null,
+                   customData: CustomData? = null,
+                   callback: (Result<Unit, Error>) -> Unit
+    ) = makeCallback({ syncCurrentUser.updateRoom(roomId, name, pushNotificationTitleOverride, isPrivate, customData) }, callback)
 
     fun deleteRoom(room: Room, callback: (Result<String, Error>) -> Unit) =
             makeCallback({ syncCurrentUser.deleteRoom(room) }, callback)

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousCurrentUser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousCurrentUser.kt
@@ -7,9 +7,7 @@ import com.pusher.chatkit.messages.Direction
 import com.pusher.chatkit.messages.Message
 import com.pusher.chatkit.messages.multipart.NewPart
 import com.pusher.chatkit.pushnotifications.PushNotifications
-import com.pusher.chatkit.rooms.Room
-import com.pusher.chatkit.rooms.RoomConsumer
-import com.pusher.chatkit.rooms.RoomListeners
+import com.pusher.chatkit.rooms.*
 import com.pusher.chatkit.rooms.toCallback
 import com.pusher.chatkit.users.User
 import com.pusher.util.Result
@@ -91,17 +89,11 @@ class SynchronousCurrentUser(
     )
 
     @JvmOverloads
-    fun updateRoom(room: Room, name: String? = null, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
-            this.updateRoom(room.id, name, isPrivate, customData)
-
-    @JvmOverloads
-    fun updateRoom(roomId: String, name: String? = null, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
-            chatManager.roomService.updateRoom(roomId, name, isPrivate, customData)
-
-    fun updateRoom(room: Room, name: String? = null, pushNotificationTitleOverride: String?, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
+    fun updateRoom(room: Room, name: String? = null, pushNotificationTitleOverride: RoomPushNotificationTitle? = null, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
             this.updateRoom(room.id, name, pushNotificationTitleOverride, isPrivate, customData)
 
-    fun updateRoom(roomId: String, name: String? = null, pushNotificationTitleOverride: String?, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
+    @JvmOverloads
+    fun updateRoom(roomId: String, name: String? = null, pushNotificationTitleOverride: RoomPushNotificationTitle? = null, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
             chatManager.roomService.updateRoom(roomId, name, pushNotificationTitleOverride, isPrivate, customData)
 
     fun deleteRoom(room: Room): Result<String, Error> =

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousCurrentUser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousCurrentUser.kt
@@ -76,6 +76,7 @@ class SynchronousCurrentUser(
     fun createRoom(
             id: String? = null,
             name: String,
+            pushNotificationTitleOverride: String? = null,
             isPrivate: Boolean = false,
             customData: CustomData? = null,
             userIds: List<String> = emptyList()
@@ -83,6 +84,7 @@ class SynchronousCurrentUser(
             id = id,
             creatorId = this.id,
             name = name,
+            pushNotificationTitleOverride = pushNotificationTitleOverride,
             isPrivate = isPrivate,
             customData = customData,
             userIds = userIds
@@ -95,6 +97,12 @@ class SynchronousCurrentUser(
     @JvmOverloads
     fun updateRoom(roomId: String, name: String? = null, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
             chatManager.roomService.updateRoom(roomId, name, isPrivate, customData)
+
+    fun updateRoom(room: Room, name: String? = null, pushNotificationTitleOverride: String?, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
+            this.updateRoom(room.id, name, pushNotificationTitleOverride, isPrivate, customData)
+
+    fun updateRoom(roomId: String, name: String? = null, pushNotificationTitleOverride: String?, isPrivate: Boolean? = null, customData: CustomData? = null): Result<Unit, Error> =
+            chatManager.roomService.updateRoom(roomId, name, pushNotificationTitleOverride, isPrivate, customData)
 
     fun deleteRoom(room: Room): Result<String, Error> =
             deleteRoom(room.id)

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/Room.kt
@@ -7,6 +7,7 @@ data class Room(
         val id: String,
         val createdById: String,
         var name: String,
+        var pushNotificationTitleOverride: String?,
         @SerializedName("private")
         var isPrivate: Boolean,
         var customData: CustomData?,
@@ -38,6 +39,7 @@ data class Room(
 
     fun deepEquals(room: Room) =
             room.name == this.name &&
+                    room.pushNotificationTitleOverride == this.pushNotificationTitleOverride &&
                     room.customData == this.customData &&
                     room.isPrivate == this.isPrivate
 }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomService.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/RoomService.kt
@@ -60,6 +60,7 @@ internal class RoomService(
             id: String?,
             creatorId: String,
             name: String,
+            pushNotificationTitleOverride: String?,
             isPrivate: Boolean,
             customData: CustomData?,
             userIds: List<String>
@@ -67,6 +68,7 @@ internal class RoomService(
             RoomCreateRequest(
                     id = id,
                     name = name,
+                    pushNotificationTitleOverride = pushNotificationTitleOverride,
                     private = isPrivate,
                     createdById = creatorId,
                     customData = customData,
@@ -108,6 +110,16 @@ internal class RoomService(
             customData: CustomData? = null
     ): Result<Unit, Error> =
             UpdateRoomRequest(name, isPrivate, customData).toJson()
+                    .flatMap { body -> client.doPut<Unit>("/rooms/${URLEncoder.encode(roomId, "UTF-8")}", body) }
+
+    fun updateRoom(
+            roomId: String,
+            name: String? = null,
+            pushNotificationTitleOverride: String?,
+            isPrivate: Boolean? = null,
+            customData: CustomData? = null
+    ): Result<Unit, Error> =
+        UpdateRoomRequestWithPNTitleOverride(name, pushNotificationTitleOverride, isPrivate, customData).toJson()
                     .flatMap { body -> client.doPut<Unit>("/rooms/${URLEncoder.encode(roomId, "UTF-8")}", body) }
 
     fun isSubscribedTo(roomId: String) =
@@ -339,9 +351,17 @@ internal data class UpdateRoomRequest(
         val customData: CustomData?
 )
 
+internal data class UpdateRoomRequestWithPNTitleOverride(
+        val name: String?,
+        val pushNotificationTitleOverride: String?,
+        val private: Boolean?,
+        val customData: CustomData?
+)
+
 private data class RoomCreateRequest(
         val id: String?,
         val name: String,
+        val pushNotificationTitleOverride: String?,
         val private: Boolean,
         val createdById: String,
         val customData: CustomData?,

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/util/Parser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/util/Parser.kt
@@ -12,6 +12,7 @@ import elements.Errors
 
 private val GSON = GsonBuilder()
         .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .serializeNulls()
         .create()
 
 internal inline fun <reified A> typeToken() =

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/RoomStoreSpek.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/RoomStoreSpek.kt
@@ -14,7 +14,7 @@ class RoomStoreSpek : Spek({
     describe("RoomStore") {
 
         fun simpleRoom(id: String, name: String, isPrivate: Boolean, customData: CustomData?) =
-                Room(id, "ham", name, isPrivate, customData, null, "2017-04-13T14:10:38Z",
+                Room(id, "ham", name, null, isPrivate, customData, null, "2017-04-13T14:10:38Z",
                         "2017-04-13T14:10:38Z",
                         "2017-04-13T14:10:38Z",
                         "2017-04-13T14:10:38Z")


### PR DESCRIPTION
This change was a bit tricky to implement as when updating the room, `null` is different than not passing.

In Java/Kotlin world, we could make use of the Builder pattern to create a `RoomUpdateRequest`. I thought this was a bit much so I took another approach that doesn't require breaking the API (but less scalable if we want to add more optional fields where `null` has different meaning than "not set").