### PR TITLE
Add authData parameters to request body

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/ChatkitTokenProvider.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/ChatkitTokenProvider.kt
@@ -66,7 +66,7 @@ data class ChatkitTokenProvider
         if (tokenParams is ChatkitTokenParams) add(tokenParams.extras)
     }.build()
 
-    private fun FormBody.Builder.add(map: Map<String, String>) = {
+    private fun FormBody.Builder.add(map: Map<String, String>) = run {
         for ((k, v) in map) {
             add(k, v)
         }


### PR DESCRIPTION
Issue: https://github.com/pusher/chatkit-android/issues/63

After digging through the git blame on this file, it seems an explicit foreach loop was replaced by making this function more kotlin-centric, but the body of the function wasn't being executed thus the parameters passed in by the `authData` map were never added to the request body.