### PR TITLE
Fix issue with new cursors being parsed to null in a UserSubscription

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/users/UserSubscriptionEventParser.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/users/UserSubscriptionEventParser.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit.users
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.pusher.chatkit.cursors.Cursor
 import com.pusher.chatkit.users.UserSubscriptionEvent.*
 import com.pusher.chatkit.util.asObject
 import com.pusher.chatkit.util.asString
@@ -37,7 +38,7 @@ internal object UserSubscriptionEventParser : DataParser<UserSubscriptionEvent> 
         "removed_from_room" -> parseAs<RemovedFromRoomEvent>()
         "room_updated" -> parseAs<RoomUpdatedEvent>()
         "room_deleted" -> parseAs<RoomDeletedEvent>()
-        "new_cursor" -> parseAs<NewCursor>()
+        "new_cursor" -> parseAs<Cursor>().map { NewCursor(it) }
         else -> Errors.other("Invalid event name: $eventName").asFailure()
     }.map { it } // Generics -_-
 }


### PR DESCRIPTION
We weren't parsing the NewCursor event correctly - the JSON we get from the server isn't wrapped in a Cursor event like previously thought, which was causing an issue with Room Subscription Events and would stop any room events from being called (e.g. room changed). We've ensured we parse it correctly and written a test to ensure this fix works.