### PR TITLE
Update to latest Beams to support multi-beams in single app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-android/compare/v1.8.1...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-android/compare/v1.8.2...HEAD)
+
+## [1.8.2](https://github.com/pusher/chatkit-android/compare/v1.8.1...v1.8.2)
+
+### Changed
+
+- Updated the Pusher Beams dependency to 1.5.1.
+
+
+### Added
+
+- The capability to allow Beams to work in the same app as Chatkit.
 
 ## [1.8.1](https://github.com/pusher/chatkit-android/compare/v1.8.0...v1.8.1)
 

--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.pusher:push-notifications-android:1.4.5'
+    implementation 'com.pusher:push-notifications-android:1.5.0'
 }
 
 bintray {

--- a/chatkit-android/build.gradle
+++ b/chatkit-android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.pusher:push-notifications-android:1.5.0'
+    implementation 'com.pusher:push-notifications-android:1.5.1'
 }
 
 bintray {

--- a/chatkit-android/src/main/kotlin/com/pusher/chatkit/BeamsPushNotifications.kt
+++ b/chatkit-android/src/main/kotlin/com/pusher/chatkit/BeamsPushNotifications.kt
@@ -9,7 +9,7 @@ import com.pusher.pushnotifications.PusherCallbackError
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.util.Result
 import elements.Error
-import com.pusher.pushnotifications.PushNotifications as Beams
+import com.pusher.pushnotifications.PushNotificationsInstance as BeamsInstance
 
 // Implementation of `PushNotifications` interface using Pusher Beams!
 class BeamsPushNotifications(
@@ -22,10 +22,11 @@ class BeamsPushNotifications(
         override fun fetchToken(userId: String): String =
                 beamsTokenProviderService.fetchToken(userId)
     }
+    private val pushNotificationsInstance = BeamsInstance(context, instanceId)
 
     override fun start(): Result<Unit, Error> {
         return try {
-            Beams.start(context, instanceId)
+            pushNotificationsInstance.start()
             Result.success(Unit)
         } catch (ex: ClassNotFoundException) {
             Result.failure(elements.OtherError("It seems like some dependencies that Push Notifications requires are missing. Check https://docs.pusher.com/chatkit for more information.", ex.cause))
@@ -37,7 +38,7 @@ class BeamsPushNotifications(
     override fun setUserId(userId: String): Result<Unit, Error> {
         val f = FutureValue<Result<Unit, Error>>()
         try {
-            Beams.setUserId(userId, tokenProvider, object : BeamsCallback<Void, PusherCallbackError> {
+            pushNotificationsInstance.setUserId(userId, tokenProvider, object : BeamsCallback<Void, PusherCallbackError> {
                 override fun onFailure(error: PusherCallbackError) {
                     f.set(Result.failure(elements.OtherError(error.message, error.cause)))
                 }
@@ -57,7 +58,7 @@ class BeamsPushNotifications(
 
     override fun stop(): Result<Unit, Error> {
         try {
-            Beams.stop()
+            pushNotificationsInstance.stop()
         } catch (ex: ClassNotFoundException) {
             return Result.failure(elements.OtherError("It seems like some dependencies that Push Notifications requires are missing. Check https://docs.pusher.com/chatkit for more information.", ex.cause))
         } catch (ex: Throwable) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 org.gradle.caching=true
 
-VERSION_NAME=1.8.1
+VERSION_NAME=1.8.2
 GROUP=com.pusher


### PR DESCRIPTION
Update the beams dependency in chatkit and use the newer way of accessing beams.

This enables others to use beams in their apps as well as Chatkit. We're calling the beams SDK inside Chatkit directly which should mean others can just follow the quick start guide (which uses the singleton) and not interfere with their apps.

We've tested this:
* updating the public demo app to use push notifications on a real device
* Added our instance of beams into the seller activity which pointed to a different instance
* Confirmed we could receive push notifications to both instances on a real device

- [x] update beams to 1.5.1
- [x] update changelog
- [x] update version numbers