### PR TITLE
Fix retrying/reporting token provider errors on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-android/compare/v1.8.3...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-android/compare/v1.8.4...HEAD)
+
+## [1.8.4](https://github.com/pusher/chatkit-android/compare/v1.8.3...v1.8.4)
+
+### Fixed
+
+- Fixed retrying/reporting `TokenProvider` errors when connecting to `ChatManager`.
 
 ## [1.8.3](https://github.com/pusher/chatkit-android/compare/v1.8.2...v1.8.3)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ buildscript {
         android_gradle_version = '3.1.1'
         android_support_version = '27.1.1'
         android_arch_version = '1.1.1'
+        spek_version = '2.0.9'
+        legacy_spek_version = '1.1.5'
         mockito_version = '2.10.0'
         constraints_layout_version = '1.1.0'
         espresso_version = '3.0.1'

--- a/chatkit-core/build.gradle
+++ b/chatkit-core/build.gradle
@@ -21,8 +21,13 @@ dependencies {
 
     testImplementation "org.mockito:mockito-inline:$mockito_version"
     testImplementation 'com.google.truth:truth:0.40'
-    testImplementation 'org.jetbrains.spek:spek-api:1.1.5'
-    testImplementation 'org.jetbrains.spek:spek-junit-platform-engine:1.1.5'
+
+    testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
+    testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
+
+    testImplementation "org.jetbrains.spek:spek-api:$legacy_spek_version"
+    testImplementation "org.jetbrains.spek:spek-junit-platform-engine:$legacy_spek_version"
+
     testImplementation 'org.junit.platform:junit-platform-runner:1.1.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.3'
     testImplementation "com.auth0:java-jwt:3.3.0"
@@ -46,7 +51,7 @@ junitPlatform {
     details 'tree'
     filters {
         engines {
-            include 'junit-jupiter', 'spek'
+            include 'junit-jupiter', 'spek', 'spek2'
         }
     }
 }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerTestUtil.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerTestUtil.kt
@@ -1,0 +1,9 @@
+package com.pusher.chatkit
+
+import com.pusher.platform.tokenProvider.TokenProvider
+
+fun createChatManager(
+        instanceLocator: String = INSTANCE_LOCATOR,
+        userId: String = Users.PUSHERINO,
+        tokenProvider: TokenProvider) =
+        ChatManager(instanceLocator, userId, TestChatkitDependencies(tokenProvider))

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerWithFailingTokenProviderSpec.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerWithFailingTokenProviderSpec.kt
@@ -1,0 +1,119 @@
+package com.pusher.chatkit
+
+import com.google.common.truth.Truth.assertThat
+import com.pusher.chatkit.ChatEvent.CurrentUserReceived
+import com.pusher.chatkit.test.InstanceActions.createDefaultRole
+import com.pusher.chatkit.test.InstanceActions.newUsers
+import com.pusher.chatkit.test.InstanceSupervisor.setUpInstanceWith
+import com.pusher.chatkit.test.InstanceSupervisor.tearDownInstance
+import com.pusher.chatkit.util.FutureValue
+import com.pusher.platform.network.Futures
+import com.pusher.platform.tokenProvider.TokenProvider
+import com.pusher.util.Result
+import elements.Error
+import elements.Errors
+import elements.emptyHeaders
+import org.junit.Assert.fail
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.Thread.sleep
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicInteger
+
+object ChatManagerWithFailingTokenProviderSpec : Spek({
+    afterEachTest(::closeChatManagers)
+    afterEachTest(::tearDownInstance)
+
+    val futureConnectionResult by memoized { FutureValue<Result<CurrentUser, Error>>() }
+    val notifiedEvents by memoized { ConcurrentLinkedQueue<ChatEvent>() }
+
+    describe("given token provider fails with 401") {
+        val tokenProviderError = Errors.response(401, emptyHeaders(), "auth expired")
+
+        val subject by memoized {
+            createChatManager(tokenProvider = object : TokenProvider {
+
+                override fun fetchToken(tokenParams: Any?)
+                        : Future<Result<String, Error>> =
+                        Futures.schedule {
+                            sleep(200) // more realistic with that delay
+                            Result.failure<String, Error>(tokenProviderError)
+                        }
+
+                override fun clearToken(token: String?) { /* nop */ }
+
+            })
+        }
+
+        describe("when connect is called") {
+            beforeEachTest {
+                subject.connect(
+                        consumer = { event -> notifiedEvents.add(event) },
+                        callback = { result -> futureConnectionResult.set(result) }
+                )
+            }
+
+            it("then the connection result indicates and contains the correct error") {
+                val connectionResult = futureConnectionResult.get()
+                if (connectionResult is Result.Failure) {
+                    val connectionError = connectionResult.error
+                    assertThat(connectionError).isEqualTo(tokenProviderError)
+                } else {
+                    fail("not true that $connectionResult is failure")
+                }
+            }
+            it("then no events are notified") {
+                futureConnectionResult.get() // wait to connect
+                assertThat(notifiedEvents).isEmpty()
+            }
+        }
+    }
+
+    describe("given token provider fails twice with a network error and then succeeds") {
+        beforeEachTest { setUpInstanceWith(createDefaultRole(), newUsers(Users.PUSHERINO)) }
+
+        val subject by memoized {
+            val testTokenProvider = TestTokenProvider(INSTANCE_ID, Users.PUSHERINO,
+                    AUTH_KEY_ID, AUTH_KEY_SECRET)
+
+            val tokenProviderError = Errors.network("connectivity issue")
+
+            createChatManager(tokenProvider = object : TokenProvider by testTokenProvider {
+
+                var errorCounter = AtomicInteger(2)
+
+                override fun fetchToken(tokenParams: Any?)
+                        : Future<Result<String, Error>> =
+                        if (errorCounter.getAndDecrement() > 0) {
+                            Futures.schedule {
+                                sleep(10) // more realistic with that tiny delay
+                                Result.failure<String, Error>(tokenProviderError)
+                            }
+                        } else {
+                            testTokenProvider.fetchToken(tokenParams)
+                        }
+
+            })
+        }
+
+        describe("when connect is called") {
+            beforeEachTest {
+                subject.connect(
+                        consumer = { event -> notifiedEvents.add(event) },
+                        callback = { result -> futureConnectionResult.set(result) }
+                )
+            }
+
+            it("then the connection result indicates success") {
+                assertThat(futureConnectionResult.get()).isInstanceOf(Result.Success::class.java)
+            }
+            it("then only the current user received event is notified") {
+                futureConnectionResult.get() // wait to connect
+                assertThat(notifiedEvents.size).isEqualTo(1)
+                assertThat(notifiedEvents.peek()).isInstanceOf(CurrentUserReceived::class.java)
+            }
+        }
+    }
+
+})

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerWithFailingTokenProviderSpec.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/ChatManagerWithFailingTokenProviderSpec.kt
@@ -13,7 +13,6 @@ import com.pusher.util.Result
 import elements.Error
 import elements.Errors
 import elements.emptyHeaders
-import org.junit.Assert.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.lang.Thread.sleep
@@ -55,12 +54,9 @@ object ChatManagerWithFailingTokenProviderSpec : Spek({
             }
 
             it("then the connection result indicates and contains the correct error") {
-                val connectionResult = futureConnectionResult.get()
-                if (connectionResult is Result.Failure) {
-                    val connectionError = connectionResult.error
-                    assertThat(connectionError).isEqualTo(tokenProviderError)
-                } else {
-                    fail("not true that $connectionResult is failure")
+                assertThat(futureConnectionResult.get()).apply {
+                    isInstanceOf(Result.Failure::class.java)
+                    isEqualTo(Result.failure<String, Error>(tokenProviderError))
                 }
             }
             it("then no events are notified") {

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/DebounceTokenProvider.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/DebounceTokenProvider.kt
@@ -13,6 +13,13 @@ internal class DebounceTokenProvider(private val original: TokenProvider) : Toke
     private var pending: Future<Result<String, Error>>? = null
 
     override fun fetchToken(tokenParams: Any?): Future<Result<String, Error>> = synchronized(this) {
+        val initialPendingSnap = pending
+        if (initialPendingSnap != null &&
+                (initialPendingSnap.isDone || initialPendingSnap.isCancelled)) {
+
+            pending = null
+        }
+
         pending ?: original.fetchToken(tokenParams).also { pending = it }
     }
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/DebounceTokenProvider.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/DebounceTokenProvider.kt
@@ -13,9 +13,9 @@ internal class DebounceTokenProvider(private val original: TokenProvider) : Toke
     private var pending: Future<Result<String, Error>>? = null
 
     override fun fetchToken(tokenParams: Any?): Future<Result<String, Error>> = synchronized(this) {
-        val initialPendingSnap = pending
-        if (initialPendingSnap != null &&
-                (initialPendingSnap.isDone || initialPendingSnap.isCancelled)) {
+        val initialPendingSnapshot = pending
+        if (initialPendingSnapshot != null &&
+                (initialPendingSnapshot.isDone || initialPendingSnapshot.isCancelled)) {
 
             pending = null
         }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/users/UserSubscription.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/users/UserSubscription.kt
@@ -18,6 +18,11 @@ internal class UserSubscription(
         logger: Logger,
         private val listeners: UserSubscriptionConsumer
 ) : Subscription {
+
+    private val initialized = AtomicBoolean(false)
+
+    private val initialState: FutureValue<Result<UserSubscriptionEvent.InitialState, Error>> = FutureValue()
+
     private val subscription = loggingSubscription(
             client = client,
             path = "users",
@@ -29,9 +34,6 @@ internal class UserSubscription(
             description = "User $userId",
             logger = logger
     )
-
-    private val initialized = AtomicBoolean(false)
-    private val initialState: FutureValue<Result<UserSubscriptionEvent.InitialState, Error>> = FutureValue()
 
     private fun consumeEvent(event: UserSubscriptionEvent) {
         if (event is UserSubscriptionEvent.InitialState

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 org.gradle.caching=true
 
-VERSION_NAME=1.8.3
+VERSION_NAME=1.8.4
 GROUP=com.pusher


### PR DESCRIPTION
Fix DebounceTokenProvider to recognise done/cancelled Futures.

Fix UserSubscription init order so that callbacks are initialized
first before a synchronous call is done through the async interface.
Splitting init and actions is a broader internal improvement already
in the backlog.

Add Spek 2 and tests verifying the above fixes.