### PR TITLE
Add comment for the getReadCursor signature to fix for v2

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorService.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/cursors/CursorService.kt
@@ -59,6 +59,10 @@ class CursorService(
         )
     }
 
+    // TODO v2: this signature isn't correct, the cursor should be an optional
+    // e.g. for the case where you have a new room with no messages (or cursors) yet!
+    // The error should additionally be more descriptive instead of just assuming you aren't
+    // subscribed to the room!
     fun getReadCursor(userId: String, roomId: String): Result<Cursor, Error> =
             (cursorsStore[userId][roomId]?.asSuccess() ?: notSubscribedToRoom(roomId).asFailure())
 


### PR DESCRIPTION
What

Added a comment for the getReadCursor to remind us to make it more sensible in v2.

Why
There is an issue where if the room is new, with no messages and therefor no cursors you get a misleading error message (that you are not subscribed to the room). In v2 we would like to make this cursor optional, with a better error messaging returned. 