### PR TITLE
Add information in the readme for spek tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,17 +87,16 @@ The tests can be run using the Gradle `test` task with the VM options mentioned 
 To run the tests directly from Android Studio you will need to install the
 [Spek](https://plugins.jetbrains.com/plugin/8564-spek/) plugin, and
 [Spek Framework](https://plugins.jetbrains.com/plugin/10915-spek-framework/).
-Both plugins are needed as older tests are written using Spek1, and newer
-tests are using Spek2.
+Both plugins are needed as older tests are written using Spek 1, and newer
+tests are using Spek 2.
 To do this go to Android Studio -> Preferences -> Plugins ->
 search for Spek, and Spek Framework and install both plugins. If you open a Spek test file
 (e.g. RoomSpek), you should now see green play buttons to run each test
 (or a test group from a file).
 
-
 In order for the tests to pass you must provide a Chatkit instance
 credential from the [dashboard](https://dash.pusher.com/chatkit/)
-to the VM - to do this edit the run configurations -> select Spek
+to the VM — to do this edit the run configurations -> select Spek
 on the left -> in the VM options field enter the following:
 
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ chatkit_integration_locator=<instance locator>
 chatkit_integration_key=<instance key>
 ```
 
+### Spek Tests
+
+Our tests are currently written using the [Spek Framework](https://www.spekframework.org/setup-android/).
+And you will need to install the Spek Plugin in Android Studio to be able to run them.
+
+You may find that you will also need to edit the run configuration and add your
+chatkit locator and chatkit key like this:
+
+```
+-Dchatkit_integration_locator=xxxx -Dchatkit_integration_key=yyy
+```
+
+Happy testing!
+
 ## Publishing
 
 ### jCenter

--- a/README.md
+++ b/README.md
@@ -83,18 +83,23 @@ It can be either a relative or absolute path.
 
 The SDK has integration tests which run against a real Chatkit server.
 
-Firstly you will need to install the
-[Spek](https://www.spekframework.org/setup-android/) plugin, and Spek Framework in
-Android Studio. To do this go to Android Studio -> Preferences -> Plugins ->
-search for Spek, and Spek Framework and install. If you open a Spek test file, you
-should now see green play buttons to run each test (or the file).
+The tests can be run using the Gradle `test` task with the VM options mentioned below set.
+To run the tests directly from Android Studio you will need to install the
+[Spek](https://plugins.jetbrains.com/plugin/8564-spek/) plugin, and
+[Spek Framework](https://plugins.jetbrains.com/plugin/10915-spek-framework/).
+To do this go to Android Studio -> Preferences -> Plugins ->
+search for Spek, and Spek Framework and install. If you open a Spek test file
+(e.g. RoomSpek), you should now see green play buttons to run each test
+(or a test group from a file).
+
 
 In order for the tests to pass you must provide a Chatkit instance
-credential to the VM - to do this edit the run configurations -> select Spek
+credential from the [dashboard](https://dash.pusher.com/chatkit/)
+to the VM - to do this edit the run configurations -> select Spek
 on the left -> in the VM options field enter the following:
 
 ```
--Dchatkit_integration_locator=xxxx -Dchatkit_integration_key=yyy
+-Dchatkit_integration_locator=<INSTANCE_LOCATOR> -Dchatkit_integration_key=<SECRET_KEY>
 ```
 
 *Important:* The tests will delete any and all resources associated with

--- a/README.md
+++ b/README.md
@@ -81,9 +81,16 @@ It can be either a relative or absolute path.
 
 ## Testing
 
-The SDK has integration tests which run against a real Chatkit server.
+The SDK has integration tests which run against a real Chatkit server. The tests
+can be run either using the Gradle task `test` or directly in Android Studio.
 
-The tests can be run using the Gradle `test` task with the VM options mentioned below set.
+In order for the tests to pass you must provide a Chatkit instance
+credential from the [dashboard](https://dash.pusher.com/chatkit/).
+
+*Important:* The tests will delete any and all resources associated with
+the instance you provide. Create a new instance for testing purposes, and do not
+share it anywhere else.
+
 To run the tests directly from Android Studio you will need to install the
 [Spek](https://plugins.jetbrains.com/plugin/8564-spek/) plugin, and
 [Spek Framework](https://plugins.jetbrains.com/plugin/10915-spek-framework/).
@@ -94,18 +101,21 @@ search for Spek, and Spek Framework and install both plugins. If you open a Spek
 (e.g. RoomSpek), you should now see green play buttons to run each test
 (or a test group from a file).
 
-In order for the tests to pass you must provide a Chatkit instance
-credential from the [dashboard](https://dash.pusher.com/chatkit/)
-to the VM — to do this edit the run configurations -> select Spek
-on the left -> in the VM options field enter the following:
+You will need to add your Chatkit test instance credentials to the VM — to do this edit
+the run configurations -> select Spek on the left -> in the VM options field
+enter the following:
 
 ```
 -Dchatkit_integration_locator=<INSTANCE_LOCATOR> -Dchatkit_integration_key=<SECRET_KEY>
 ```
 
-*Important:* The tests will delete any and all resources associated with
-the instance you provide. Create a new instance for testing purposes, and do not
-share it anywhere else.
+To run the Gradle test task, you will need to add your Chatkit test instance
+credentials to your global `gradle.properties` file:
+
+```
+chatkit_integration_locator=<INSTANCE_LOCATOR>
+chatkit_integration_key=<SECRET_KEY>
+```
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -82,32 +82,24 @@ It can be either a relative or absolute path.
 ## Testing
 
 The SDK has integration tests which run against a real Chatkit server.
-In order to run them, you must provide Chatkit instance credentials in
-your Gradle `local.properties` (or as `-D` arguments to the VM executing
-the tests)
 
-*Important:* The tests may delete any and all resources associated with
-the instance you provide. Create a new one. Do not share it with any other
-use.
+Firstly you will need to install the
+[Spek Framework](https://www.spekframework.org/setup-android/) plugin in
+Android Studio. To do this go to Android Studio -> Preferences -> Plugins ->
+search for Spek and install. If you open a Spek test file, you should now see
+green play buttons to run each test (or the file).
 
-```
-chatkit_integration_locator=<instance locator>
-chatkit_integration_key=<instance key>
-```
-
-### Spek Tests
-
-Our tests are currently written using the [Spek Framework](https://www.spekframework.org/setup-android/).
-And you will need to install the Spek Plugin in Android Studio to be able to run them.
-
-You may find that you will also need to edit the run configuration and add your
-chatkit locator and chatkit key like this:
+In order for the tests to pass you must provide a Chatkit instance
+credential to the VM - to do this edit the run configurations -> select Spek
+on the left -> in the VM options field enter the following:
 
 ```
 -Dchatkit_integration_locator=xxxx -Dchatkit_integration_key=yyy
 ```
 
-Happy testing!
+*Important:* The tests will delete any and all resources associated with
+the instance you provide. Create a new instance for testing purposes, and do not
+share it anywhere else.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To run the tests directly from Android Studio you will need to install the
 Both plugins are needed as older tests are written using Spek1, and newer
 tests are using Spek2.
 To do this go to Android Studio -> Preferences -> Plugins ->
-search for Spek, and Spek Framework and install. If you open a Spek test file
+search for Spek, and Spek Framework and install both plugins. If you open a Spek test file
 (e.g. RoomSpek), you should now see green play buttons to run each test
 (or a test group from a file).
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ enter the following:
 ```
 
 To run the Gradle test task, you will need to add your Chatkit test instance
-credentials to your global `gradle.properties` file:
+credentials to your global `~/.gradle/gradle.properties` file:
 
 ```
 chatkit_integration_locator=<INSTANCE_LOCATOR>

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The tests can be run using the Gradle `test` task with the VM options mentioned 
 To run the tests directly from Android Studio you will need to install the
 [Spek](https://plugins.jetbrains.com/plugin/8564-spek/) plugin, and
 [Spek Framework](https://plugins.jetbrains.com/plugin/10915-spek-framework/).
+Both plugins are needed as older tests are written using Spek1, and newer
+tests are using Spek2.
 To do this go to Android Studio -> Preferences -> Plugins ->
 search for Spek, and Spek Framework and install. If you open a Spek test file
 (e.g. RoomSpek), you should now see green play buttons to run each test

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ It can be either a relative or absolute path.
 The SDK has integration tests which run against a real Chatkit server.
 
 Firstly you will need to install the
-[Spek Framework](https://www.spekframework.org/setup-android/) plugin in
+[Spek](https://www.spekframework.org/setup-android/) plugin, and Spek Framework in
 Android Studio. To do this go to Android Studio -> Preferences -> Plugins ->
-search for Spek and install. If you open a Spek test file, you should now see
-green play buttons to run each test (or the file).
+search for Spek, and Spek Framework and install. If you open a Spek test file, you
+should now see green play buttons to run each test (or the file).
 
 In order for the tests to pass you must provide a Chatkit instance
 credential to the VM - to do this edit the run configurations -> select Spek


### PR DESCRIPTION
What:
Added instructions on how to get set up with spek in the readme, as a sub heading under testing. This includes installing the plugin and editing the run configuration.

Why:
We need to let people how to run the tests. The editing run configuration is a step I forget about usually, so worth documenting :-)