### PR TITLE
Fix Room Spek Custom Data Tests

### DIFF
--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
@@ -2,34 +2,20 @@ package com.pusher.chatkit
 
 import com.google.common.truth.Truth.assertThat
 import com.pusher.chatkit.Rooms.GENERAL
-import com.pusher.chatkit.Rooms.NOT_GENERAL
 import com.pusher.chatkit.Rooms.SAMPLE_CUSTOM_DATA
 import com.pusher.chatkit.Users.ALICE
 import com.pusher.chatkit.Users.PUSHERINO
 import com.pusher.chatkit.Users.SUPER_USER
-import com.pusher.chatkit.rooms.Room
-import com.pusher.chatkit.rooms.RoomEvent
-import com.pusher.chatkit.rooms.RoomPushNotificationTitle
-import com.pusher.chatkit.test.InstanceActions.changeRoomName
 import com.pusher.chatkit.test.InstanceActions.createDefaultRole
-import com.pusher.chatkit.test.InstanceActions.deleteRoom
 import com.pusher.chatkit.test.InstanceActions.newRoom
 import com.pusher.chatkit.test.InstanceActions.newUsers
 import com.pusher.chatkit.test.InstanceSupervisor.setUpInstanceWith
 import com.pusher.chatkit.test.InstanceSupervisor.tearDownInstance
-import com.pusher.chatkit.test.run
-import com.pusher.chatkit.users.User
 import com.pusher.chatkit.util.FutureValue
-import com.pusher.util.Result.Failure
-import com.pusher.util.Result.Success
-import junit.framework.Assert.*
+import junit.framework.Assert.assertNotNull
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 object RoomCustomDataSpek : Spek({
     beforeEachTest(::tearDownInstance)
@@ -64,11 +50,11 @@ object RoomCustomDataSpek : Spek({
                     newRoom(GENERAL, PUSHERINO, ALICE)
             )
 
-            var superUserRoomUpdated by FutureValue<Room>()
+            var superUserRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             val superUser = chatFor(SUPER_USER).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
-                        superUserRoomUpdated = event.room
+                        superUserRoomUpdatedEvent = event
                     }
                 }
             }.assumeSuccess()
@@ -78,11 +64,11 @@ object RoomCustomDataSpek : Spek({
                     "custom" to "data"
             )
 
-            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             chatFor(ALICE).connectFor { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
-                        alicesUpdatedGeneralRoom = event.room
+                        alicesRoomUpdatedEvent = event
                     }
                 }
             }
@@ -93,8 +79,8 @@ object RoomCustomDataSpek : Spek({
 
             ).assumeSuccess()
 
-            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(newCustomData)
-            assertThat(superUserRoomUpdated.customData).isEqualTo(newCustomData)
+            assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
+            assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
             assertNotNull(superUser.rooms[0].customData)
             assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
         }
@@ -110,20 +96,20 @@ object RoomCustomDataSpek : Spek({
                     )
             )
 
-            var superUserRoomUpdated by FutureValue<Room>()
+            var superUserRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             val superUser = chatFor(SUPER_USER).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
-                        superUserRoomUpdated = event.room
+                        superUserRoomUpdatedEvent = event
                     }
                 }
             }.assumeSuccess()
 
-            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             chatFor(ALICE).connectFor { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
-                        alicesUpdatedGeneralRoom = event.room
+                        alicesRoomUpdatedEvent = event
                     }
                 }
             }
@@ -138,8 +124,8 @@ object RoomCustomDataSpek : Spek({
                     customData = newCustomData
             ).assumeSuccess()
 
-            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(newCustomData)
-            assertThat(superUserRoomUpdated.customData).isEqualTo(newCustomData)
+            assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
+            assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
             assertNotNull(superUser.rooms[0].customData)
             assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
         }
@@ -155,21 +141,21 @@ object RoomCustomDataSpek : Spek({
                     )
             )
 
-            var superUserRoomUpdated by FutureValue<Room>()
+            var superUserRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             val superUser = chatFor(SUPER_USER).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
-                        superUserRoomUpdated = event.room
+                        superUserRoomUpdatedEvent = event
                     }
                 }
             }.assumeSuccess()
 
-            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
             chatFor(ALICE).connectFor { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
 
-                        alicesUpdatedGeneralRoom = event.room
+                        alicesRoomUpdatedEvent = event
                     }
                 }
             }
@@ -181,8 +167,8 @@ object RoomCustomDataSpek : Spek({
                     customData = emptyCustomData
             ).assumeSuccess()
 
-            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(emptyCustomData)
-            assertThat(superUserRoomUpdated.customData).isEqualTo(emptyCustomData)
+            assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(emptyCustomData)
+            assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(emptyCustomData)
             assertNotNull(superUser.rooms[0].customData)
             assertThat(superUser.rooms[0].customData).isEqualTo(emptyCustomData)
         }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
@@ -13,9 +13,8 @@ import com.pusher.chatkit.test.InstanceSupervisor.setUpInstanceWith
 import com.pusher.chatkit.test.InstanceSupervisor.tearDownInstance
 import com.pusher.chatkit.util.FutureValue
 import junit.framework.Assert.assertNotNull
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 object RoomCustomDataSpek : Spek({
     beforeEachTest(::tearDownInstance)
@@ -65,23 +64,23 @@ object RoomCustomDataSpek : Spek({
             )
 
             var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
-            chatFor(ALICE).connectFor { event ->
+            val alice = chatFor(ALICE).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
                         alicesRoomUpdatedEvent = event
                     }
                 }
-            }
+            }.assumeSuccess()
 
             superUser.updateRoom(
                     room = superUser.generalRoom,
                     customData = newCustomData
-
             ).assumeSuccess()
 
             assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
             assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
-            assertNotNull(superUser.rooms[0].customData)
+
+            assertThat(alice.rooms[0].customData).isEqualTo(newCustomData)
             assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
         }
 
@@ -106,13 +105,13 @@ object RoomCustomDataSpek : Spek({
             }.assumeSuccess()
 
             var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
-            chatFor(ALICE).connectFor { event ->
+            val alice = chatFor(ALICE).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
                         alicesRoomUpdatedEvent = event
                     }
                 }
-            }
+            }.assumeSuccess()
 
             val newCustomData = mapOf(
                     "replaced" to "some",
@@ -126,7 +125,8 @@ object RoomCustomDataSpek : Spek({
 
             assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
             assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(newCustomData)
-            assertNotNull(superUser.rooms[0].customData)
+
+            assertThat(alice.rooms[0].customData).isEqualTo(newCustomData)
             assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
         }
 
@@ -151,14 +151,14 @@ object RoomCustomDataSpek : Spek({
             }.assumeSuccess()
 
             var alicesRoomUpdatedEvent by FutureValue<ChatEvent.RoomUpdated>()
-            chatFor(ALICE).connectFor { event ->
+            val alice = chatFor(ALICE).connect { event ->
                 when (event) {
                     is ChatEvent.RoomUpdated -> {
 
                         alicesRoomUpdatedEvent = event
                     }
                 }
-            }
+            }.assumeSuccess()
 
             val emptyCustomData = mapOf<String, String>()
 
@@ -169,9 +169,9 @@ object RoomCustomDataSpek : Spek({
 
             assertThat(alicesRoomUpdatedEvent.room.customData).isEqualTo(emptyCustomData)
             assertThat(superUserRoomUpdatedEvent.room.customData).isEqualTo(emptyCustomData)
-            assertNotNull(superUser.rooms[0].customData)
+
+            assertThat(alice.rooms[0].customData).isEqualTo(emptyCustomData)
             assertThat(superUser.rooms[0].customData).isEqualTo(emptyCustomData)
         }
-
     }
 })

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
@@ -17,8 +17,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 object RoomCustomDataSpek : Spek({
-    beforeEachTest(::tearDownInstance)
     afterEachTest(::closeChatManagers)
+    afterEachTest(::tearDownInstance)
 
     describe("room custom data") {
 

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataSpek.kt
@@ -1,0 +1,191 @@
+package com.pusher.chatkit
+
+import com.google.common.truth.Truth.assertThat
+import com.pusher.chatkit.Rooms.GENERAL
+import com.pusher.chatkit.Rooms.NOT_GENERAL
+import com.pusher.chatkit.Rooms.SAMPLE_CUSTOM_DATA
+import com.pusher.chatkit.Users.ALICE
+import com.pusher.chatkit.Users.PUSHERINO
+import com.pusher.chatkit.Users.SUPER_USER
+import com.pusher.chatkit.rooms.Room
+import com.pusher.chatkit.rooms.RoomEvent
+import com.pusher.chatkit.rooms.RoomPushNotificationTitle
+import com.pusher.chatkit.test.InstanceActions.changeRoomName
+import com.pusher.chatkit.test.InstanceActions.createDefaultRole
+import com.pusher.chatkit.test.InstanceActions.deleteRoom
+import com.pusher.chatkit.test.InstanceActions.newRoom
+import com.pusher.chatkit.test.InstanceActions.newUsers
+import com.pusher.chatkit.test.InstanceSupervisor.setUpInstanceWith
+import com.pusher.chatkit.test.InstanceSupervisor.tearDownInstance
+import com.pusher.chatkit.test.run
+import com.pusher.chatkit.users.User
+import com.pusher.chatkit.util.FutureValue
+import com.pusher.util.Result.Failure
+import com.pusher.util.Result.Success
+import junit.framework.Assert.*
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+object RoomCustomDataSpek : Spek({
+    beforeEachTest(::tearDownInstance)
+    afterEachTest(::closeChatManagers)
+
+    describe("room custom data") {
+
+        it("creates a room with custom data") {
+            setUpInstanceWith(createDefaultRole(), newUsers(PUSHERINO, ALICE))
+
+            val customData = mapOf(
+                    "this is" to listOf("complex", "data"),
+                    "this key" to "has string value"
+            )
+
+            val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
+
+            val room = pusherino.createRoom(
+                    id = null,
+                    name = GENERAL,
+                    customData = customData
+            ).assumeSuccess()
+
+            assertThat(room.name).isEqualTo(GENERAL)
+            assertThat(room.customData).isEqualTo(customData)
+        }
+
+        it("adds customData to an existing room") {
+            setUpInstanceWith(
+                    createDefaultRole(),
+                    newUsers(PUSHERINO, ALICE),
+                    newRoom(GENERAL, PUSHERINO, ALICE)
+            )
+
+            var superUserRoomUpdated by FutureValue<Room>()
+            val superUser = chatFor(SUPER_USER).connect { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+                        superUserRoomUpdated = event.room
+                    }
+                }
+            }.assumeSuccess()
+
+            val newCustomData = mapOf(
+                    "added" to "some",
+                    "custom" to "data"
+            )
+
+            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            chatFor(ALICE).connectFor { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+                        alicesUpdatedGeneralRoom = event.room
+                    }
+                }
+            }
+
+            superUser.updateRoom(
+                    room = superUser.generalRoom,
+                    customData = newCustomData
+
+            ).assumeSuccess()
+
+            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(newCustomData)
+            assertThat(superUserRoomUpdated.customData).isEqualTo(newCustomData)
+            assertNotNull(superUser.rooms[0].customData)
+            assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
+        }
+
+        it("updates existing customData to a room") {
+            setUpInstanceWith(
+                    createDefaultRole(),
+                    newUsers(PUSHERINO, ALICE),
+                    newRoom(
+                            name = GENERAL,
+                            customData = SAMPLE_CUSTOM_DATA,
+                            userNames = *arrayOf(PUSHERINO, ALICE)
+                    )
+            )
+
+            var superUserRoomUpdated by FutureValue<Room>()
+            val superUser = chatFor(SUPER_USER).connect { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+                        superUserRoomUpdated = event.room
+                    }
+                }
+            }.assumeSuccess()
+
+            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            chatFor(ALICE).connectFor { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+                        alicesUpdatedGeneralRoom = event.room
+                    }
+                }
+            }
+
+            val newCustomData = mapOf(
+                    "replaced" to "some",
+                    "custom" to "data"
+            )
+
+            superUser.updateRoom(
+                    room = superUser.generalRoom,
+                    customData = newCustomData
+            ).assumeSuccess()
+
+            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(newCustomData)
+            assertThat(superUserRoomUpdated.customData).isEqualTo(newCustomData)
+            assertNotNull(superUser.rooms[0].customData)
+            assertThat(superUser.rooms[0].customData).isEqualTo(newCustomData)
+        }
+
+        it("updates customData to an empty map") {
+            setUpInstanceWith(
+                    createDefaultRole(),
+                    newUsers(PUSHERINO, ALICE),
+                    newRoom(
+                            name = GENERAL,
+                            customData = SAMPLE_CUSTOM_DATA,
+                            userNames = *arrayOf(PUSHERINO, ALICE)
+                    )
+            )
+
+            var superUserRoomUpdated by FutureValue<Room>()
+            val superUser = chatFor(SUPER_USER).connect { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+                        superUserRoomUpdated = event.room
+                    }
+                }
+            }.assumeSuccess()
+
+            var alicesUpdatedGeneralRoom by FutureValue<Room>()
+            chatFor(ALICE).connectFor { event ->
+                when (event) {
+                    is ChatEvent.RoomUpdated -> {
+
+                        alicesUpdatedGeneralRoom = event.room
+                    }
+                }
+            }
+
+            val emptyCustomData = mapOf<String, String>()
+
+            superUser.updateRoom(
+                    room = superUser.generalRoom,
+                    customData = emptyCustomData
+            ).assumeSuccess()
+
+            assertThat(alicesUpdatedGeneralRoom.customData).isEqualTo(emptyCustomData)
+            assertThat(superUserRoomUpdated.customData).isEqualTo(emptyCustomData)
+            assertNotNull(superUser.rooms[0].customData)
+            assertThat(superUser.rooms[0].customData).isEqualTo(emptyCustomData)
+        }
+
+    }
+})

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataTest.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomCustomDataTest.kt
@@ -16,7 +16,7 @@ import junit.framework.Assert.assertNotNull
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-object RoomCustomDataSpek : Spek({
+object RoomCustomDataTest : Spek({
     afterEachTest(::closeChatManagers)
     afterEachTest(::tearDownInstance)
 

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -93,8 +93,7 @@ object RoomSpek : Spek({
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
             val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
-
-
+            
             var lastMessageAtRoomUpdatedEvent by FutureValue<RoomEvent.RoomUpdated>()
             var unreadCountRoomUpdatedEvent by FutureValue<RoomEvent.RoomUpdated>()
             alice.subscribeToRoomMultipart(alice.generalRoom) { event ->

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -85,26 +85,37 @@ object RoomSpek : Spek({
             assertThat(updatedRoom.name).isEqualTo(NOT_GENERAL)
         }
 
-        it("updates the unread count and last message at when '$GENERAL' receives a new message") {
+        it("notifies '$ALICE' when room '$GENERAL' receives a new message") {
             setUpInstanceWith(
                     createDefaultRole(),
                     newUsers(ALICE, PUSHERINO),
-                    newRoom(GENERAL, ALICE, PUSHERINO)
-            )
+                    newRoom(GENERAL, ALICE, PUSHERINO))
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
-            assertNull(alice.generalRoom.lastMessageAt)
-            assertEquals(0, alice.generalRoom.unreadCount)
-
-            var lastMessageAt by FutureValue<String>()
             val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
-            pusherino.subscribeToRoomMultipart(pusherino.generalRoom) { event ->
-                if (event is RoomEvent.RoomUpdated) lastMessageAt = event.room.lastMessageAt!!
+
+
+            var lastMessageAtRoomUpdatedEvent by FutureValue<RoomEvent.RoomUpdated>()
+            var unreadCountRoomUpdatedEvent by FutureValue<RoomEvent.RoomUpdated>()
+            alice.subscribeToRoomMultipart(alice.generalRoom) { event ->
+                if (event is RoomEvent.RoomUpdated) {
+                    if (event.room.unreadCount == 1) {
+                        unreadCountRoomUpdatedEvent = event
+                    } else {
+                        lastMessageAtRoomUpdatedEvent = event
+                    }
+                }
             }
+
             pusherino.sendSimpleMessage(pusherino.generalRoom, "hi")
 
-            assertEquals(lastMessageAt, alice.generalRoom.lastMessageAt)
-            assertEquals(1, alice.generalRoom.unreadCount)
+            assertThat(lastMessageAtRoomUpdatedEvent.room.lastMessageAt).isNotEmpty()
+            assertThat(unreadCountRoomUpdatedEvent.room.unreadCount).isEqualTo(1)
+
+            assertThat(alice.rooms[0].unreadCount).isEqualTo(1)
+            
+            assertThat(alice.rooms[0].lastMessageAt).isEqualTo(
+                    lastMessageAtRoomUpdatedEvent.room.lastMessageAt)
         }
 
         it("notifies '$PUSHERINO' when room '$GENERAL' is deleted") {

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -85,23 +85,7 @@ object RoomSpek : Spek({
             assertThat(updatedRoom.name).isEqualTo(NOT_GENERAL)
         }
 
-        it("updates the unread counter when '$GENERAL' receives a new message") {
-            setUpInstanceWith(
-                    createDefaultRole(),
-                    newUsers(ALICE, PUSHERINO),
-                    newRoom(GENERAL, ALICE, PUSHERINO)
-            )
-
-            val alice = chatFor(ALICE).connect().assumeSuccess()
-            assertEquals(0, alice.generalRoom.unreadCount)
-
-            val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
-            pusherino.sendSimpleMessage(pusherino.generalRoom, "hi")
-
-            assertEquals(1, alice.generalRoom.unreadCount)
-        }
-
-        it("updates the last message at when '$GENERAL' receives a new message") {
+        it("updates the unread count and last message at when '$GENERAL' receives a new message") {
             setUpInstanceWith(
                     createDefaultRole(),
                     newUsers(ALICE, PUSHERINO),
@@ -110,6 +94,7 @@ object RoomSpek : Spek({
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
             assertNull(alice.generalRoom.lastMessageAt)
+            assertEquals(0, alice.generalRoom.unreadCount)
 
             var lastMessageAt by FutureValue<String>()
             val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
@@ -119,6 +104,7 @@ object RoomSpek : Spek({
             pusherino.sendSimpleMessage(pusherino.generalRoom, "hi")
 
             assertEquals(lastMessageAt, alice.generalRoom.lastMessageAt)
+            assertEquals(1, alice.generalRoom.unreadCount)
         }
 
         it("notifies '$PUSHERINO' when room '$GENERAL' is deleted") {

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -113,7 +113,6 @@ object RoomSpek : Spek({
             assertThat(unreadCountRoomUpdatedEvent.room.unreadCount).isEqualTo(1)
 
             assertThat(alice.rooms[0].unreadCount).isEqualTo(1)
-            
             assertThat(alice.rooms[0].lastMessageAt).isEqualTo(
                     lastMessageAtRoomUpdatedEvent.room.lastMessageAt)
         }

--- a/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
+++ b/chatkit-core/src/integrationTest/kotlin/com/pusher/chatkit/RoomSpek.kt
@@ -93,12 +93,12 @@ object RoomSpek : Spek({
             )
 
             val alice = chatFor(ALICE).connect().assumeSuccess()
-            assertEquals(alice.generalRoom.unreadCount, 0)
+            assertEquals(0, alice.generalRoom.unreadCount)
 
             val pusherino = chatFor(PUSHERINO).connect().assumeSuccess()
             pusherino.sendSimpleMessage(pusherino.generalRoom, "hi")
 
-            assertEquals(alice.generalRoom.unreadCount, 1)
+            assertEquals(1, alice.generalRoom.unreadCount)
         }
 
         it("updates the last message at when '$GENERAL' receives a new message") {
@@ -118,7 +118,7 @@ object RoomSpek : Spek({
             }
             pusherino.sendSimpleMessage(pusherino.generalRoom, "hi")
 
-            assertEquals(alice.generalRoom.lastMessageAt, lastMessageAt)
+            assertEquals(lastMessageAt, alice.generalRoom.lastMessageAt)
         }
 
         it("notifies '$PUSHERINO' when room '$GENERAL' is deleted") {


### PR DESCRIPTION
What
Fixed the room custom data tests as they were pretty flaky and refactored into their own file to reduce how big room spek is getting!

Why
Flaky tests are not great for us to know if things are actually broken :) This should fix that!