### PR TITLE
Make travis ci run if it's a pull request originating from pusher/cha…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 dist: trusty
 jdk: oraclejdk8
 
-# safelist
-branches:
-  only:
-  - master
+if: type = pull_request
+if: repo = pusher/chatkit-android
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: trusty
 jdk: oraclejdk8
 
-if: type = pull_request
-if: repo = pusher/chatkit-android
+if: type = pull_request AND repo = pusher/chatkit-android
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
What:
Make travis ci run for any pull request only if it originates from pusher/chatkit-android - to ensure other random people can't run their builds on our pipeline.

Why:
We're using a feature branch at the moment and it'd be nice if our tests ran before they got merged in.

Caveats:
Not entirely sure if this is the right syntax for travis ci or whether it will be super unhappy 🤷‍♀ 