### PR TITLE
Add spurious wakeup protection and fix race condition in test code

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/SynchronousChatManager.kt
@@ -182,7 +182,8 @@ class SynchronousChatManager : AppHookListener {
 
     private fun consumeUserSubscriptionEvent(incomingEvent: UserSubscriptionEvent) {
         synchronized(populatedInitialStateLock) {  // wait for initial state to be processed first
-            if (!populatedInitialState) populatedInitialStateLock.wait()
+            // loop for spurious wakeup protection https://en.wikipedia.org/wiki/Spurious_wakeup
+            while (!populatedInitialState) populatedInitialStateLock.wait()
         }
 
         if (incomingEvent is UserSubscriptionEvent.InitialState) {


### PR DESCRIPTION
Random failures have been observed on a test faking the backend
which looked like CurrentUserReceived not being delivered as the
first event:
├─ UserEnrichmentErrorFunctionalTest ✔
│  └─ given error when fetching user joining the room ✔
│     └─ when connect is called ✔
│        ├─ then the connect result is successful ✔
│        └─ then the error is notified ✘ Not true that <ErrorOccurred(error=NetworkError(reason=test error))> is an instance of <com.pusher.chatkit.ChatEvent$CurrentUserReceived>. It is an instance of <com.pusher.chatkit.ChatEvent$ErrorOccurred>

Investigation lead to discovery of the lack of protection against spurious wakeups, which got fixed.