### PR TITLE
Remove kotlin-reflect dependency

### DIFF
--- a/chatkit-core/build.gradle
+++ b/chatkit-core/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api 'com.squareup.okhttp3:okhttp:3.12.6'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'com.google.truth:truth:0.40'


### PR DESCRIPTION
It is not used and is not expected to come in useful in the future.
It weights 2.5MB so it is nearly two times the size of kotlin-stdlib.