### PR TITLE
Remove dependency on JVM 7 extension of kotlin-stdlib

### DIFF
--- a/chatkit-core/build.gradle
+++ b/chatkit-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
         api "com.pusher:pusher-platform-core:$pusher_platform_version"
     }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     api 'com.squareup.okhttp3:okhttp:3.12.6'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"


### PR DESCRIPTION
We want chatkit-core to be as pure Kotlin as it is reasonably possible
at the current state of the project.
More insight:
https://medium.com/@mbonnin/the-different-kotlin-stdlibs-explained-83d7c6bf293
https://stackoverflow.com/questions/51858596/which-standard-library-to-use-in-kotlin

The article actually suggests also removing it for Android specific
stuff but as that's automatically added by AS when creating a new
Android project, I think it's better to trust AS.
The downside mentioned in the article is just 3k bloat which will be
there most likely either way for any Android Kotlin app,
so not a biggie.