### PR TITLE
Joined rooms unread count received

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/UnreadCountReceivedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/UnreadCountReceivedReducer.kt
@@ -1,0 +1,18 @@
+package com.pusher.chatkit.rooms.state
+
+import com.pusher.chatkit.state.State
+import com.pusher.chatkit.state.UnreadCountReceived
+import org.reduxkotlin.reducerForActionType
+
+internal val unreadCountReceivedReducer =
+    reducerForActionType<State, UnreadCountReceived> { state, action ->
+        checkNotNull(state.joinedRoomsState)
+
+        state.with(
+            joinedRoomsState = JoinedRoomsState(
+                state.joinedRoomsState.rooms,
+                state.joinedRoomsState.unreadCounts.plus(action.roomId to action.unreadCount)
+            ),
+            auxiliaryState = state.auxiliaryState.with(action)
+        )
+    }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Actions.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Actions.kt
@@ -30,3 +30,8 @@ internal data class ReconnectJoinedRoom(
     val room: JoinedRoomInternalType,
     val unreadCount: Int?
 ) : Action()
+
+internal data class UnreadCountReceived(
+    val roomId: String,
+    val unreadCount: Int
+) : Action()

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/AuxiliaryState.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/AuxiliaryState.kt
@@ -10,7 +10,8 @@ internal data class AuxiliaryState(
     val leftRoom: LastChange<LeftRoom>?,
     val roomUpdated: LastChange<RoomUpdated>?,
     val roomDeleted: LastChange<RoomDeleted>?,
-    val reconnectJoinedRoom: LastChange<ReconnectJoinedRoom>?
+    val reconnectJoinedRoom: LastChange<ReconnectJoinedRoom>?,
+    val unreadCountReceived: LastChange<UnreadCountReceived>?
 ) {
 
     companion object {
@@ -21,7 +22,8 @@ internal data class AuxiliaryState(
             leftRoom = null,
             roomUpdated = null,
             roomDeleted = null,
-            reconnectJoinedRoom = null
+            reconnectJoinedRoom = null,
+            unreadCountReceived = null
         )
     }
 
@@ -39,6 +41,8 @@ internal data class AuxiliaryState(
                 copy(nextVersion, roomUpdated = LastChange(nextVersion, action))
             is ReconnectJoinedRoom ->
                 copy(nextVersion, reconnectJoinedRoom = LastChange(nextVersion, action))
+            is UnreadCountReceived ->
+                copy(nextVersion, unreadCountReceived = LastChange(nextVersion, action))
         }
 
     private val nextVersion = version + 1

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDifferTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDifferTest.kt
@@ -6,6 +6,7 @@ import com.pusher.chatkit.state.LeftRoom
 import com.pusher.chatkit.state.ReconnectJoinedRoom
 import com.pusher.chatkit.state.RoomUpdated
 import com.pusher.chatkit.state.State
+import com.pusher.chatkit.state.UnreadCountReceived
 import io.mockk.every
 import io.mockk.mockk
 import org.reduxkotlin.GetState
@@ -58,6 +59,31 @@ class JoinedRoomsStateDifferTest : Spek({
 
             it("then the result contains RoomUpdated action") {
                 assertThat(actions).containsExactly(RoomUpdated(room = roomOneUpdated))
+            }
+        }
+
+        describe("when an unread count is updated") {
+            val actions = differ.toActions(
+                newRooms = listOf(roomOne, roomTwo),
+                newUnreadCounts = mapOf(roomOneId to 4)
+            )
+
+            it("then the result contains UnreadCountReceived action") {
+                assertThat(actions).containsExactly(
+                    UnreadCountReceived(roomId = roomOneId, unreadCount = 4))
+            }
+        }
+
+        describe("when an room and unread count is updated") {
+            val actions = differ.toActions(
+                newRooms = listOf(roomOneUpdated, roomTwo),
+                newUnreadCounts = mapOf(roomOneId to 4)
+            )
+
+            it("then the result contains UnreadCountReceived action") {
+                assertThat(actions).containsExactly(
+                    RoomUpdated(room = roomOneUpdated),
+                    UnreadCountReceived(roomId = roomOneId, unreadCount = 4))
             }
         }
     }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/UnreadCountReceivedReducerTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/UnreadCountReceivedReducerTest.kt
@@ -1,0 +1,38 @@
+package com.pusher.chatkit.rooms.state
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import com.pusher.chatkit.state.State
+import com.pusher.chatkit.state.UnreadCountReceived
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object UnreadCountReceivedReducerTest : Spek({
+
+    describe("given two rooms") {
+        val givenState = State(
+            joinedRoomsState = JoinedRoomsState(
+                rooms = mapOf(
+                    roomOneId to roomOne,
+                    roomTwoId to roomTwo
+                ),
+                unreadCounts = mapOf(
+                    roomOneId to 1,
+                    roomTwoId to 2
+                )
+            )
+        )
+
+        describe("when an unread count is received") {
+            val newState = unreadCountReceivedReducer(givenState,
+                UnreadCountReceived(roomOneId, 3))
+
+            it("then the unread count is updated") {
+                assertThat(newState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
+                    roomOneId to 3,
+                    roomTwoId to 2
+                )
+            }
+        }
+    }
+})


### PR DESCRIPTION
# What
Added a `UnreadCountReceieved` state, action, and reducer. They are currently fired if a second initial event is received with different unreadCounts.

Questions:

1. Should the `UpdatedRoom` event and action have the unread count too? How do we receive a new unread count for a room without getting an initialState event again?