### PR TITLE
Introduce ChatState to group all chat related State

### DIFF
--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
@@ -1,10 +1,10 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.JoinedRoom
-import com.pusher.chatkit.state.chatReducerForActionType
+import com.pusher.chatkit.state.chatStateReducer
 
 internal val joinedRoomReducer =
-    chatReducerForActionType<JoinedRoom> { chatState, action ->
+    chatStateReducer<JoinedRoom> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
@@ -1,23 +1,19 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.JoinedRoom
-import com.pusher.chatkit.state.State
-import org.reduxkotlin.reducerForActionType
+import com.pusher.chatkit.state.chatReducerForActionType
 
 internal val joinedRoomReducer =
-    reducerForActionType<State, JoinedRoom> { state, action ->
-        val chatState = state.chatState
+    chatReducerForActionType<JoinedRoom> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room
         val joinedRoomUnreadCount = action.room.id to action.unreadCount
 
-        state.with(
-            chatState.with(
-                JoinedRoomsState(
-                    chatState.joinedRoomsState.rooms + joinedRoom,
-                    chatState.joinedRoomsState.unreadCounts + joinedRoomUnreadCount
-                )
+        chatState.with(
+            JoinedRoomsState(
+                chatState.joinedRoomsState.rooms + joinedRoom,
+                chatState.joinedRoomsState.unreadCounts + joinedRoomUnreadCount
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomReducer.kt
@@ -6,15 +6,18 @@ import org.reduxkotlin.reducerForActionType
 
 internal val joinedRoomReducer =
     reducerForActionType<State, JoinedRoom> { state, action ->
-        checkNotNull(state.joinedRoomsState)
+        val chatState = state.chatState
+        checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room
         val joinedRoomUnreadCount = action.room.id to action.unreadCount
 
         state.with(
-            JoinedRoomsState(
-                state.joinedRoomsState.rooms + joinedRoom,
-                state.joinedRoomsState.unreadCounts + joinedRoomUnreadCount
+            chatState.with(
+                JoinedRoomsState(
+                    chatState.joinedRoomsState.rooms + joinedRoom,
+                    chatState.joinedRoomsState.unreadCounts + joinedRoomUnreadCount
+                )
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
@@ -6,9 +6,12 @@ import org.reduxkotlin.reducerForActionType
 
 internal val joinedRoomsReceivedReducer =
     reducerForActionType<State, JoinedRoomsReceived> { state, action ->
+        val chatState = state.chatState
 
         val joinedRooms = action.rooms.map { it.id to it }.toMap()
         val joinedRoomsState = JoinedRoomsState(joinedRooms, action.unreadCounts)
 
-        state.with(joinedRoomsState)
+        state.with(
+            chatState.with(joinedRoomsState)
+        )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
@@ -1,17 +1,12 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.JoinedRoomsReceived
-import com.pusher.chatkit.state.State
-import org.reduxkotlin.reducerForActionType
+import com.pusher.chatkit.state.chatReducerForActionType
 
 internal val joinedRoomsReceivedReducer =
-    reducerForActionType<State, JoinedRoomsReceived> { state, action ->
-        val chatState = state.chatState
-
+    chatReducerForActionType<JoinedRoomsReceived> { chatState, action ->
         val joinedRooms = action.rooms.map { it.id to it }.toMap()
         val joinedRoomsState = JoinedRoomsState(joinedRooms, action.unreadCounts)
 
-        state.with(
-            chatState.with(joinedRoomsState)
-        )
+        chatState.with(joinedRoomsState)
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedReducer.kt
@@ -1,10 +1,10 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.JoinedRoomsReceived
-import com.pusher.chatkit.state.chatReducerForActionType
+import com.pusher.chatkit.state.chatStateReducer
 
 internal val joinedRoomsReceivedReducer =
-    chatReducerForActionType<JoinedRoomsReceived> { chatState, action ->
+    chatStateReducer<JoinedRoomsReceived> { chatState, action ->
         val joinedRooms = action.rooms.map { it.id to it }.toMap()
         val joinedRoomsState = JoinedRoomsState(joinedRooms, action.unreadCounts)
 

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDiffer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDiffer.kt
@@ -9,7 +9,7 @@ import org.reduxkotlin.GetState
 
 internal class JoinedRoomsStateDiffer(private val stateGetter: GetState<State>) {
 
-    fun stateExists() = stateGetter().joinedRoomsState != null
+    fun stateExists() = stateGetter().chatState.joinedRoomsState != null
 
     fun toActions(
         newRooms: List<JoinedRoomInternalType>,
@@ -19,7 +19,7 @@ internal class JoinedRoomsStateDiffer(private val stateGetter: GetState<State>) 
             roomUpdatedActions(newRooms) +
             leftRoomActions(newRooms)
 
-    private val currentRooms get() = stateGetter().joinedRoomsState!!.rooms
+    private val currentRooms get() = stateGetter().chatState.joinedRoomsState!!.rooms
 
     private fun joinedRoomActions(
         newRooms: List<JoinedRoomInternalType>,

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
@@ -1,20 +1,16 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.LeftRoom
-import com.pusher.chatkit.state.State
-import org.reduxkotlin.reducerForActionType
+import com.pusher.chatkit.state.chatReducerForActionType
 
 internal val leftRoomReducer =
-    reducerForActionType<State, LeftRoom> { state, action ->
-        val chatState = state.chatState
+    chatReducerForActionType<LeftRoom> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
-        state.with(
-            chatState.with(
-                JoinedRoomsState(
-                    chatState.joinedRoomsState.rooms - action.roomId,
-                    chatState.joinedRoomsState.unreadCounts - action.roomId
-                )
+        chatState.with(
+            JoinedRoomsState(
+                chatState.joinedRoomsState.rooms - action.roomId,
+                chatState.joinedRoomsState.unreadCounts - action.roomId
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
@@ -6,12 +6,15 @@ import org.reduxkotlin.reducerForActionType
 
 internal val leftRoomReducer =
     reducerForActionType<State, LeftRoom> { state, action ->
-        checkNotNull(state.joinedRoomsState)
+        val chatState = state.chatState
+        checkNotNull(chatState.joinedRoomsState)
 
         state.with(
-            JoinedRoomsState(
-                state.joinedRoomsState.rooms - action.roomId,
-                state.joinedRoomsState.unreadCounts - action.roomId
+            chatState.with(
+                JoinedRoomsState(
+                    chatState.joinedRoomsState.rooms - action.roomId,
+                    chatState.joinedRoomsState.unreadCounts - action.roomId
+                )
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/LeftRoomReducer.kt
@@ -1,10 +1,10 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.LeftRoom
-import com.pusher.chatkit.state.chatReducerForActionType
+import com.pusher.chatkit.state.chatStateReducer
 
 internal val leftRoomReducer =
-    chatReducerForActionType<LeftRoom> { chatState, action ->
+    chatStateReducer<LeftRoom> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         chatState.with(

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
@@ -6,12 +6,15 @@ import org.reduxkotlin.reducerForActionType
 
 internal val roomDeletedReducer =
     reducerForActionType<State, RoomDeleted> { state, action ->
-        checkNotNull(state.joinedRoomsState)
+        val chatState = state.chatState
+        checkNotNull(chatState.joinedRoomsState)
 
         state.with(
-            JoinedRoomsState(
-                state.joinedRoomsState.rooms - action.roomId,
-                state.joinedRoomsState.unreadCounts - action.roomId
+            chatState.with(
+                JoinedRoomsState(
+                    chatState.joinedRoomsState.rooms - action.roomId,
+                    chatState.joinedRoomsState.unreadCounts - action.roomId
+                )
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
@@ -1,10 +1,10 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.RoomDeleted
-import com.pusher.chatkit.state.chatReducerForActionType
+import com.pusher.chatkit.state.chatStateReducer
 
 internal val roomDeletedReducer =
-    chatReducerForActionType<RoomDeleted> { chatState, action ->
+    chatStateReducer<RoomDeleted> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         chatState.with(

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedReducer.kt
@@ -1,20 +1,16 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.RoomDeleted
-import com.pusher.chatkit.state.State
-import org.reduxkotlin.reducerForActionType
+import com.pusher.chatkit.state.chatReducerForActionType
 
 internal val roomDeletedReducer =
-    reducerForActionType<State, RoomDeleted> { state, action ->
-        val chatState = state.chatState
+    chatReducerForActionType<RoomDeleted> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
-        state.with(
-            chatState.with(
-                JoinedRoomsState(
-                    chatState.joinedRoomsState.rooms - action.roomId,
-                    chatState.joinedRoomsState.unreadCounts - action.roomId
-                )
+        chatState.with(
+            JoinedRoomsState(
+                chatState.joinedRoomsState.rooms - action.roomId,
+                chatState.joinedRoomsState.unreadCounts - action.roomId
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
@@ -6,14 +6,17 @@ import org.reduxkotlin.reducerForActionType
 
 internal val roomUpdatedReducer =
     reducerForActionType<State, RoomUpdated> { state, action ->
-        checkNotNull(state.joinedRoomsState)
+        val chatState = state.chatState
+        checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room
 
         state.with(
-            JoinedRoomsState(
-                state.joinedRoomsState.rooms + joinedRoom,
-                state.joinedRoomsState.unreadCounts
+            chatState.with(
+                JoinedRoomsState(
+                    chatState.joinedRoomsState.rooms + joinedRoom,
+                    chatState.joinedRoomsState.unreadCounts
+                )
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
@@ -1,10 +1,10 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.RoomUpdated
-import com.pusher.chatkit.state.chatReducerForActionType
+import com.pusher.chatkit.state.chatStateReducer
 
 internal val roomUpdatedReducer =
-    chatReducerForActionType<RoomUpdated> { chatState, action ->
+    chatStateReducer<RoomUpdated> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedReducer.kt
@@ -1,22 +1,18 @@
 package com.pusher.chatkit.rooms.state
 
 import com.pusher.chatkit.state.RoomUpdated
-import com.pusher.chatkit.state.State
-import org.reduxkotlin.reducerForActionType
+import com.pusher.chatkit.state.chatReducerForActionType
 
 internal val roomUpdatedReducer =
-    reducerForActionType<State, RoomUpdated> { state, action ->
-        val chatState = state.chatState
+    chatReducerForActionType<RoomUpdated> { chatState, action ->
         checkNotNull(chatState.joinedRoomsState)
 
         val joinedRoom = action.room.id to action.room
 
-        state.with(
-            chatState.with(
-                JoinedRoomsState(
-                    chatState.joinedRoomsState.rooms + joinedRoom,
-                    chatState.joinedRoomsState.unreadCounts
-                )
+        chatState.with(
+            JoinedRoomsState(
+                chatState.joinedRoomsState.rooms + joinedRoom,
+                chatState.joinedRoomsState.unreadCounts
             )
         )
     }

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/ChatState.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/ChatState.kt
@@ -1,0 +1,18 @@
+package com.pusher.chatkit.state
+
+import com.pusher.chatkit.rooms.state.JoinedRoomsState
+
+internal data class ChatState(
+    val joinedRoomsState: JoinedRoomsState?
+) {
+    companion object {
+        fun initial() =
+            ChatState(
+                joinedRoomsState = null
+            )
+    }
+
+    fun with(joinedRoomsState: JoinedRoomsState) = copy(
+        joinedRoomsState = joinedRoomsState
+    )
+}

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
@@ -1,0 +1,16 @@
+package com.pusher.chatkit.state
+
+import org.reduxkotlin.ReducerForActionType
+import org.reduxkotlin.reducerForActionType
+
+/**
+ * Convenience method to create a reducer with operates only on the ChatState section of the State
+ * hierarchy.
+ */
+internal inline fun <reified TAction> chatReducerForActionType(
+    crossinline reducer: ReducerForActionType<ChatState, TAction>
+) = reducerForActionType<State, TAction> { state, action ->
+    state.with(
+        chatState = reducer(state.chatState, action)
+    )
+}

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
@@ -4,11 +4,20 @@ import org.reduxkotlin.ReducerForActionType
 import org.reduxkotlin.reducerForActionType
 
 /**
+ * Create a reducer for the whole State
+ */
+internal inline fun <reified TAction> stateReducer(
+    crossinline reducer: ReducerForActionType<State, TAction>
+) = reducerForActionType<State, TAction> { state, action ->
+    reducer(state, action)
+}
+
+/**
  * Create a slice reducer for ChatState branch
  */
 internal inline fun <reified TAction> chatStateReducer(
     crossinline reducer: ReducerForActionType<ChatState, TAction>
-) = reducerForActionType<State, TAction> { state, action ->
+) = stateReducer<TAction> { state, action ->
     state.with(
         chatState = reducer(state.chatState, action)
     )

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/Reducers.kt
@@ -4,10 +4,9 @@ import org.reduxkotlin.ReducerForActionType
 import org.reduxkotlin.reducerForActionType
 
 /**
- * Convenience method to create a reducer with operates only on the ChatState section of the State
- * hierarchy.
+ * Create a slice reducer for ChatState branch
  */
-internal inline fun <reified TAction> chatReducerForActionType(
+internal inline fun <reified TAction> chatStateReducer(
     crossinline reducer: ReducerForActionType<ChatState, TAction>
 ) = reducerForActionType<State, TAction> { state, action ->
     state.with(

--- a/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/State.kt
+++ b/chatkit-core/src/main/kotlin/com/pusher/chatkit/state/State.kt
@@ -1,18 +1,16 @@
 package com.pusher.chatkit.state
 
-import com.pusher.chatkit.rooms.state.JoinedRoomsState
-
 internal data class State(
-    val joinedRoomsState: JoinedRoomsState?
+    val chatState: ChatState
 ) {
 
     companion object {
         fun initial() = State(
-            joinedRoomsState = null
+            chatState = ChatState.initial()
         )
     }
 
-    fun with(joinedRoomsState: JoinedRoomsState) = copy(
-        joinedRoomsState = joinedRoomsState
+    fun with(chatState: ChatState) = copy(
+        chatState = chatState
     )
 }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomTest.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit.rooms.state
 
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import com.pusher.chatkit.state.ChatState
 import com.pusher.chatkit.state.JoinedRoom
 import com.pusher.chatkit.state.State
 import org.spekframework.spek2.Spek
@@ -10,52 +11,60 @@ import org.spekframework.spek2.style.specification.describe
 class JoinedRoomTest : Spek({
 
     describe("given no rooms") {
-        val givenState = State(joinedRoomsState = JoinedRoomsState(
-            rooms = emptyMap(),
-            unreadCounts = emptyMap()
-        ))
+        val givenState = State.initial().with(
+            ChatState.initial().with(
+                joinedRoomsState = JoinedRoomsState(
+                    rooms = emptyMap(),
+                    unreadCounts = emptyMap()
+                )
+            )
+        )
 
         describe("when a room is joined") {
             val joinedRoom = JoinedRoom(roomOne, unreadCount = 1)
             val newState = joinedRoomReducer(givenState, joinedRoom)
 
             it("then the state contains the expected room") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnly(
-                        roomOneId to roomOne
-                )
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnly(roomOneId to roomOne)
             }
 
             it("then the state contains the expected unread count") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
-                        roomOneId to 1
-                )
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnlyUnreadCounts(roomOneId to 1)
             }
         }
     }
 
     describe("given one room") {
-        val givenState = State(joinedRoomsState = JoinedRoomsState(
-            rooms = mapOf(
-                roomOneId to roomOne
-            ),
-            unreadCounts = mapOf(
-                roomOneId to 1
+        val givenState = State.initial().with(
+            ChatState.initial().with(
+                joinedRoomsState = JoinedRoomsState(
+                    rooms = mapOf(
+                        roomOneId to roomOne
+                    ),
+                    unreadCounts = mapOf(
+                        roomOneId to 1
+                    )
+                )
             )
-        ))
+        )
 
         describe("when a room is joined") {
             val joinedRoom = JoinedRoom(roomTwo, unreadCount = 2)
             val newState = joinedRoomReducer(givenState, joinedRoom)
 
             it("then the state contains the expected room") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnly(
+                assertThat(newState.chatState.joinedRoomsState).isNotNull().containsOnly(
                     roomOneId to roomOne,
                     roomTwoId to roomTwo
                 )
             }
 
             it("then the state contains the expected unread count") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
+                assertThat(newState.chatState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
                     roomOneId to 1,
                     roomTwoId to 2
                 )

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomTest.kt
@@ -42,12 +42,8 @@ class JoinedRoomTest : Spek({
         val givenState = State.initial().with(
             ChatState.initial().with(
                 joinedRoomsState = JoinedRoomsState(
-                    rooms = mapOf(
-                        roomOneId to roomOne
-                    ),
-                    unreadCounts = mapOf(
-                        roomOneId to 1
-                    )
+                    rooms = mapOf(roomOneId to roomOne),
+                    unreadCounts = mapOf(roomOneId to 1)
                 )
             )
         )
@@ -57,17 +53,21 @@ class JoinedRoomTest : Spek({
             val newState = joinedRoomReducer(givenState, joinedRoom)
 
             it("then the state contains the expected room") {
-                assertThat(newState.chatState.joinedRoomsState).isNotNull().containsOnly(
-                    roomOneId to roomOne,
-                    roomTwoId to roomTwo
-                )
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnly(
+                        roomOneId to roomOne,
+                        roomTwoId to roomTwo
+                    )
             }
 
             it("then the state contains the expected unread count") {
-                assertThat(newState.chatState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
-                    roomOneId to 1,
-                    roomTwoId to 2
-                )
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnlyUnreadCounts(
+                        roomOneId to 1,
+                        roomTwoId to 2
+                    )
             }
         }
     }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedIntegrationTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.pusher.chatkit.rooms.api.JoinedRoomApiType
 import com.pusher.chatkit.rooms.api.JoinedRoomApiTypeMapper
 import com.pusher.chatkit.rooms.api.RoomMembershipApiType
 import com.pusher.chatkit.rooms.api.RoomReadStateApiType
+import com.pusher.chatkit.state.ChatState
 import com.pusher.chatkit.state.LeftRoom
 import com.pusher.chatkit.state.ReconnectJoinedRoom
 import com.pusher.chatkit.state.RoomUpdated
@@ -52,12 +53,17 @@ internal object JoinedRoomsReceivedIntegrationTest : Spek({
         val dateApiTypeMapper = DateApiTypeMapper()
         val joinedRoomApiTypeMapper = JoinedRoomApiTypeMapper(dateApiTypeMapper)
         val dispatcher by memoized { mockk<Dispatcher>(relaxed = true) }
-        val testState = State(joinedRoomsState = JoinedRoomsState(
-            rooms = mapOf(
-                "id1" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeOne)
-            ),
-            unreadCounts = mapOf(
-                "id1" to 1))
+        val testState = State.initial().with(
+            ChatState.initial().with(
+                JoinedRoomsState(
+                    rooms = mapOf(
+                        "id1" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeOne)
+                    ),
+                    unreadCounts = mapOf(
+                        "id1" to 1
+                    )
+                )
+            )
         )
         val differ = JoinedRoomsStateDiffer { testState }
         val userSubscriptionDispatcher by memoized {
@@ -176,15 +182,20 @@ internal object JoinedRoomsReceivedIntegrationTest : Spek({
         val dateApiTypeMapper = DateApiTypeMapper()
         val joinedRoomApiTypeMapper = JoinedRoomApiTypeMapper(dateApiTypeMapper)
         val dispatcher by memoized { mockk<Dispatcher>(relaxed = true) }
-        val testState = State(joinedRoomsState = JoinedRoomsState(
-            rooms = mapOf(
-                "id1" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeOne),
-                "id2" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeTwo)
-            ),
-            unreadCounts = mapOf(
-                "id1" to 1,
-                "id2" to 2
-            )))
+        val testState = State.initial().with(
+            ChatState.initial().with(
+                JoinedRoomsState(
+                    rooms = mapOf(
+                        "id1" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeOne),
+                        "id2" to joinedRoomApiTypeMapper.toRoomInternalType(roomApiTypeTwo)
+                    ),
+                    unreadCounts = mapOf(
+                        "id1" to 1,
+                        "id2" to 2
+                    )
+                )
+            )
+        )
         val differ = JoinedRoomsStateDiffer { testState }
         val userSubscriptionDispatcher by memoized {
             UserSubscriptionDispatcher(

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsReceivedTest.kt
@@ -14,67 +14,77 @@ class JoinedRoomsReceivedTest : Spek({
 
         describe("when no rooms are received") {
             val joinedRoomsReceived = JoinedRoomsReceived(
-                    rooms = emptyList(),
-                    unreadCounts = emptyMap()
+                rooms = emptyList(),
+                unreadCounts = emptyMap()
             )
             val newState = joinedRoomsReceivedReducer(initialState, joinedRoomsReceived)
 
             it("then the state will be empty") {
-                assertThat(newState.joinedRoomsState).isNotNull().isEmpty()
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .isEmpty()
             }
         }
 
         describe("when two rooms with unread counts are received") {
             val joinedRoomsReceived = JoinedRoomsReceived(
-                    rooms = listOf(
-                            roomOne,
-                            roomTwo
-                    ),
-                    unreadCounts = mapOf(
-                            roomOneId to 1,
-                            roomTwoId to 2
-                    )
+                rooms = listOf(
+                    roomOne,
+                    roomTwo
+                ),
+                unreadCounts = mapOf(
+                    roomOneId to 1,
+                    roomTwoId to 2
+                )
             )
             val newState = joinedRoomsReceivedReducer(initialState, joinedRoomsReceived)
 
             it("then the state contains the expected rooms") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnly(
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnly(
                         roomOneId to roomOne,
                         roomTwoId to roomTwo
-                )
+                    )
             }
 
             it("then the state contains the expected unread counts") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnlyUnreadCounts(
                         roomOneId to 1,
                         roomTwoId to 2
-                )
+                    )
             }
         }
 
         describe("when two rooms with one missing unread count are received") {
             val joinedRoomsReceived = JoinedRoomsReceived(
-                    rooms = listOf(
-                            roomOne,
-                            roomTwo
-                    ),
-                    unreadCounts = mapOf(
-                            roomOneId to 1
-                    )
+                rooms = listOf(
+                    roomOne,
+                    roomTwo
+                ),
+                unreadCounts = mapOf(
+                    roomOneId to 1
+                )
             )
             val newState = joinedRoomsReceivedReducer(initialState, joinedRoomsReceived)
 
             it("then the state contains the expected rooms") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnly(
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnly(
                         roomOneId to roomOne,
                         roomTwoId to roomTwo
-                )
+                    )
             }
 
             it("then the state contains the expected unread counts") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnlyUnreadCounts(
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnlyUnreadCounts(
                         roomOneId to 1
-                )
+                    )
             }
         }
     }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDifferTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/JoinedRoomsStateDifferTest.kt
@@ -16,7 +16,7 @@ class JoinedRoomsStateDifferTest : Spek({
 
     describe("given one room") {
         val state = mockk<GetState<State>>(relaxed = true)
-        every { state().joinedRoomsState } returns JoinedRoomsState(
+        every { state().chatState.joinedRoomsState } returns JoinedRoomsState(
             rooms = mapOf(roomOneId to roomOne),
             unreadCounts = mapOf(roomOneId to 1)
         )
@@ -35,7 +35,7 @@ class JoinedRoomsStateDifferTest : Spek({
 
     describe("given two rooms") {
         val state = mockk<GetState<State>>()
-        every { state().joinedRoomsState } returns JoinedRoomsState(
+        every { state().chatState.joinedRoomsState } returns JoinedRoomsState(
             rooms = mapOf(roomOneId to roomOne, roomTwoId to roomTwo),
             unreadCounts = mapOf(roomOneId to 1, roomTwoId to 2)
         )

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/LeftRoomTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/LeftRoomTest.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit.rooms.state
 
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import com.pusher.chatkit.state.ChatState
 import com.pusher.chatkit.state.LeftRoom
 import com.pusher.chatkit.state.State
 import org.spekframework.spek2.Spek
@@ -10,15 +11,17 @@ import org.spekframework.spek2.style.specification.describe
 class LeftRoomTest : Spek({
 
     describe("given two rooms") {
-        val givenState = State(
-            joinedRoomsState = JoinedRoomsState(
-                rooms = mapOf(
-                    roomOneId to roomOne,
-                    roomTwoId to roomTwo
-                ),
-                unreadCounts = mapOf(
-                    roomOneId to 1,
-                    roomTwoId to 2
+        val givenState = State.initial().with(
+            ChatState.initial().with(
+                joinedRoomsState = JoinedRoomsState(
+                    rooms = mapOf(
+                        roomOneId to roomOne,
+                        roomTwoId to roomTwo
+                    ),
+                    unreadCounts = mapOf(
+                        roomOneId to 1,
+                        roomTwoId to 2
+                    )
                 )
             )
         )
@@ -27,7 +30,9 @@ class LeftRoomTest : Spek({
             val newState = leftRoomReducer(givenState, LeftRoom(roomOneId))
 
             it("then the state no longer contains the room") {
-                assertThat(newState.joinedRoomsState).isNotNull().containsOnly(roomTwoId to roomTwo)
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
+                    .containsOnly(roomTwoId to roomTwo)
             }
         }
     }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/RoomDeletedTest.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit.rooms.state
 
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import com.pusher.chatkit.state.ChatState
 import com.pusher.chatkit.state.RoomDeleted
 import com.pusher.chatkit.state.State
 import org.spekframework.spek2.Spek
@@ -10,15 +11,17 @@ import org.spekframework.spek2.style.specification.describe
 class RoomDeletedTest : Spek({
 
     describe("given two rooms") {
-        val givenState = State(
-            joinedRoomsState = JoinedRoomsState(
-                rooms = mapOf(
-                    roomOneId to roomOne,
-                    roomTwoId to roomTwo
-                ),
-                unreadCounts = mapOf(
-                    roomOneId to 1,
-                    roomTwoId to 2
+        val givenState = State.initial().with(
+            ChatState.initial().with(
+                joinedRoomsState = JoinedRoomsState(
+                    rooms = mapOf(
+                        roomOneId to roomOne,
+                        roomTwoId to roomTwo
+                    ),
+                    unreadCounts = mapOf(
+                        roomOneId to 1,
+                        roomTwoId to 2
+                    )
                 )
             )
         )
@@ -30,7 +33,8 @@ class RoomDeletedTest : Spek({
             )
 
             it("then the state contains only the non-deleted room") {
-                assertThat(newState.joinedRoomsState).isNotNull()
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
                     .containsOnly(roomTwoId to roomTwo)
             }
         }

--- a/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedTest.kt
+++ b/chatkit-core/src/test/kotlin/com/pusher/chatkit/rooms/state/RoomUpdatedTest.kt
@@ -2,6 +2,7 @@ package com.pusher.chatkit.rooms.state
 
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import com.pusher.chatkit.state.ChatState
 import com.pusher.chatkit.state.RoomUpdated
 import com.pusher.chatkit.state.State
 import org.spekframework.spek2.Spek
@@ -10,15 +11,17 @@ import org.spekframework.spek2.style.specification.describe
 class RoomUpdatedTest : Spek({
 
     describe("given two rooms") {
-        val givenState = State(
-            joinedRoomsState = JoinedRoomsState(
-                rooms = mapOf(
-                    roomOneId to roomOne,
-                    roomTwoId to roomTwo
-                ),
-                unreadCounts = mapOf(
-                    roomOneId to 1,
-                    roomTwoId to 2
+        val givenState = State.initial().with(
+            ChatState.initial().with(
+                joinedRoomsState = JoinedRoomsState(
+                    rooms = mapOf(
+                        roomOneId to roomOne,
+                        roomTwoId to roomTwo
+                    ),
+                    unreadCounts = mapOf(
+                        roomOneId to 1,
+                        roomTwoId to 2
+                    )
                 )
             )
         )
@@ -27,12 +30,14 @@ class RoomUpdatedTest : Spek({
             val newState = roomUpdatedReducer(givenState, RoomUpdated(roomOneUpdated))
 
             it("then the state contains the updated room") {
-                assertThat(newState.joinedRoomsState).isNotNull()
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
                     .contains(roomOneId to roomOneUpdated)
             }
 
             it("then the state contains the non-updated room") {
-                assertThat(newState.joinedRoomsState).isNotNull()
+                assertThat(newState.chatState.joinedRoomsState)
+                    .isNotNull()
                     .contains(roomTwoId to roomTwo)
             }
         }


### PR DESCRIPTION
A couple of notes on things probably look a little pointless right now, but will be useful as the state grows:

- By having each Sub`State` provide an `initial()` method, even if it's trivial, and having these cascade down the hierarchy, it is easy for tests to construct a starting state to modify.
- Some methods are being called using well spaced syntax and labelled args, because more args are expected v soon.